### PR TITLE
Enable TravisCI to work on forked repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: go
 go: stable
 install:
-    - go get gopkg.in/yaml.v2
-    - go get golang.org/x/crypto/ssh/terminal
-script: tests/integration.sh
+    # Handle forks by copying this checkout to the expected fork directory
+    - mkdir -p ${GOPATH}/src/github.com/mozilla/OneCRL-Tools
+    - rsync -az ${TRAVIS_BUILD_DIR}/ $HOME/gopath/src/github.com/mozilla/OneCRL-Tools/
+    # Now install dependencies
+    - go get -t ./...
+script:
+    - go test -v ./...
+    - tests/integration.sh

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # OneCRL-Tools
 
-[![Build Status](https://travis-ci.org/mozmark/OneCRL-Tools.svg?branch=master)](https://travis-ci.org/mozmark/OneCRL-Tools)
+[![Build Status](https://travis-ci.org/mozilla/OneCRL-Tools.svg?branch=master)](https://travis-ci.org/mozilla/OneCRL-Tools)
 
 Some tools for supporting OneCRL

--- a/oneCRL2CSV/README.md
+++ b/oneCRL2CSV/README.md
@@ -7,7 +7,7 @@ You need to have [Go](https://golang.org) intalled.
 Check out OneCRL-Tools to your go root and do a:
 
 ```
-go install github.com/mozmark/OneCRL-Tools/oneCRL2CSV
+go install github.com/mozilla/OneCRL-Tools/oneCRL2CSV
 ```
 
 ## Running

--- a/oneCRL2RevocationsTxt/README.md
+++ b/oneCRL2RevocationsTxt/README.md
@@ -7,7 +7,7 @@ You need to have [Go](https://golang.org) intalled.
 Check out OneCRL-Tools to your go root and do a:
 
 ```
-go install github.com/mozmark/OneCRL-Tools/oneCRL2RevocationsTxt
+go install github.com/mozilla/OneCRL-Tools/oneCRL2RevocationsTxt
 ```
 
 ## Running

--- a/oneCRLDiff/README.md
+++ b/oneCRLDiff/README.md
@@ -7,7 +7,7 @@ You need to have [Go](https://golang.org) intalled.
 Check out OneCRL-Tools to your go root and do a:
 
 ```
-go install github.com/mozmark/OneCRL-Tools/oneCRLDiff
+go install github.com/mozilla/OneCRL-Tools/oneCRLDiff
 ```
 
 ## Running

--- a/tests/integration.sh
+++ b/tests/integration.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
 echo -n "Testing oneCRL2RevocationsTxt installation ..."
-go install github.com/mozilla/OneCRL-Tools/oneCRL2RevocationsTxt &>/tmp/oneCRL2RevocationsTxt-install.out
+go install ./oneCRL2RevocationsTxt &>/tmp/oneCRL2RevocationsTxt-install.out
 if [ $? -ne 0 ]
 then
 	echo " fail"
-	echo "FAIL: go install github.com/mozilla/OneCRL-Tools/oneCRL2RevocationsTxt"
+	echo "FAIL: go install ./oneCRL2RevocationsTxt"
 	cat /tmp/oneCRL2RevocationsTxt-install.out
 	exit 5
 fi

--- a/util/bugs.go
+++ b/util/bugs.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"github.com/mozmark/OneCRL-Tools/config"
+	"github.com/mozilla/OneCRL-Tools/config"
 )
 
 type AttachmentFlag struct {


### PR DESCRIPTION
This extends @cr 's commit in PR #42 handling the error in invocation, renaming the imports, and fixing Travis to handle forked repositories OK.