### PR TITLE
20170908 generate historical diff

### DIFF
--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -96,7 +96,7 @@ func getDataFromURL(url string, user string, pass string) ([]byte, error) {
 	return ioutil.ReadAll(resp.Body)
 }
 
-func FetchExistingRevocations(url string) ([]string, error) {
+func FetchExistingRecords(url string) (*Records, error) {
 	conf := config.GetConfig()
 
 	if len(url) == 0 {
@@ -107,8 +107,6 @@ func FetchExistingRevocations(url string) ([]string, error) {
 		fmt.Printf("Got URL data\n")
 	}
 
-	var existing []string
-
 	user, pass := conf.KintoUser, conf.KintoPassword
 
 	res := new(Records)
@@ -118,11 +116,17 @@ func FetchExistingRevocations(url string) ([]string, error) {
 	}
 
 	err = json.Unmarshal(data, res)
+	return res, err
+}
+
+func FetchExistingRevocations(url string) ([]string, error) {
+	res, err := FetchExistingRecords(url)
+
 	if nil != err {
 		return nil, err
 	}
 
-	existing = make([]string, len(res.Data))
+	existing := make([]string, len(res.Data))
 	for idx := range res.Data {
 		existing[idx] = StringFromRecord(res.Data[idx])
 	}

--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -30,6 +30,7 @@ type OneCRLUpdate struct {
 }
 
 type Record struct {
+	Id			string `json:"id"`
 	IssuerName   string `json:"issuerName"`
 	SerialNumber string `json:"serialNumber"`
 	Subject      string `json:"subject,omitempty"`

--- a/salesforce/salesforce.go
+++ b/salesforce/salesforce.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"net/http"
 	"strings"
 )
 
@@ -22,6 +23,8 @@ type RevokedCertInfo struct {
 	CRLs		  []string
 	CSN			  string
 	CertName	  string
+	SerialNumber  string
+	Reason		  string
 }
 
 
@@ -51,9 +54,41 @@ func FetchSalesforceCSV(stream io.ReadCloser) SalesforceCSV {
 	return records
 }
 
+func FetchRevokedCertInfoFrom(location string) ([]RevokedCertInfo, error) {
+	var stream io.ReadCloser
+
+	if 0 == strings.Index(strings.ToUpper(location), "HTTP") {
+		if 0 != strings.Index(strings.ToUpper(location), "HTTPS") {
+			// cowardly refuse to get cert info from a non-https URL
+			return make([]RevokedCertInfo, 0), errors.New("Cowardly refusing to load data from a non-HTTPS URL")
+		}
+		fmt.Printf("loading salesforce data from %s\n", location)
+
+		// get the stream from URL
+		r, err := http.Get(location)
+		if err != nil {
+			return make([]RevokedCertInfo, 0), errors.New(fmt.Sprintf("problem fetching salesforce data from URL %s\n", err))
+		}
+		defer r.Body.Close()
+
+		stream = r.Body
+	} else {
+		fmt.Printf("loading salesforce data from %s\n", location)
+		// get the stream from a file
+		csvfile, err := os.Open(location)
+		if err != nil {
+			return make([]RevokedCertInfo, 0), errors.New(fmt.Sprintf("problem loading salesforce data from file %s\n", err))
+		}
+
+		stream = io.ReadCloser(csvfile)
+	}
+
+	return FetchRevokedCertInfo(stream), nil
+}
+
 func FetchRevokedCertInfo(stream io.ReadCloser) []RevokedCertInfo {
 	records := FetchSalesforceCSV(stream)
-	revoked := make([]RevokedCertInfo, len(records.Rows))
+	certs := make([]RevokedCertInfo, len(records.Rows))
 
 	for _, each := range records.Rows {
 		certInfo := RevokedCertInfo{}
@@ -61,15 +96,20 @@ func FetchRevokedCertInfo(stream io.ReadCloser) []RevokedCertInfo {
 		certInfo.PEM = each[records.ColumnNames["PEM Info"]]
 		certInfo.AlternateCRL = each[records.ColumnNames["Alternate CRL"]]
 		certInfo.CRLs = strings.Split(each[records.ColumnNames["CRL URL(s)"]] + ", " + certInfo.AlternateCRL, ", ")
+		certInfo.Reason= each[records.ColumnNames["RFC 5280 Revocation Reason Code"]]
 
 		// Also get some data for more helpful errors
 		certInfo.CSN = each[records.ColumnNames["Certificate Serial Number"]]
 		certInfo.CertName = each[records.ColumnNames["CA Owner/Certificate Name"]]
 
-		revoked = append(revoked, certInfo)
+		// And get some data for reconciling OneCRL entries and CCADB entries
+		// for reporting
+		certInfo.SerialNumber= each[records.ColumnNames["Certificate Serial Number"]]
+
+		certs = append(certs, certInfo)
 	}
 
-	return revoked
+	return certs
 }
 
 func CertDataFromSalesforcePEM (PEM string) ([]byte, error) {

--- a/salesforce/salesforce.go
+++ b/salesforce/salesforce.go
@@ -25,6 +25,7 @@ type RevokedCertInfo struct {
 	CertName	  string
 	SerialNumber  string
 	Reason		  string
+	ValidTo		  string
 }
 
 func FetchSalesforceCSV(stream io.ReadCloser) SalesforceCSV {
@@ -96,6 +97,7 @@ func FetchRevokedCertInfo(stream io.ReadCloser) []RevokedCertInfo {
 		certInfo.AlternateCRL = each[records.ColumnNames["Alternate CRL"]]
 		certInfo.CRLs = strings.Split(each[records.ColumnNames["CRL URL(s)"]] + ", " + certInfo.AlternateCRL, ", ")
 		certInfo.Reason= each[records.ColumnNames["RFC 5280 Revocation Reason Code"]]
+		certInfo.ValidTo= each[records.ColumnNames["Valid To [GMT]"]]
 
 		// Also get some data for more helpful errors
 		certInfo.CSN = each[records.ColumnNames["Certificate Serial Number"]]

--- a/salesforce/salesforce.go
+++ b/salesforce/salesforce.go
@@ -27,7 +27,6 @@ type RevokedCertInfo struct {
 	Reason		  string
 }
 
-
 func FetchSalesforceCSV(stream io.ReadCloser) SalesforceCSV {
 	records := SalesforceCSV{}
 
@@ -88,7 +87,7 @@ func FetchRevokedCertInfoFrom(location string) ([]RevokedCertInfo, error) {
 
 func FetchRevokedCertInfo(stream io.ReadCloser) []RevokedCertInfo {
 	records := FetchSalesforceCSV(stream)
-	certs := make([]RevokedCertInfo, len(records.Rows))
+	certs := make([]RevokedCertInfo, 0)
 
 	for _, each := range records.Rows {
 		certInfo := RevokedCertInfo{}

--- a/salesforce2OneCRL/data/exceptions.json
+++ b/salesforce2OneCRL/data/exceptions.json
@@ -74,25 +74,14 @@
     "issuerName": "MF4xCzAJBgNVBAYTAlVTMTAwLgYDVQQKEydIeWRyYW50SUQgKEF2YWxhbmNoZSBDbG91ZCBDb3Jwb3JhdGlvbikxHTAbBgNVBAMTFEh5ZHJhbnRJRCBTU0wgSUNBIEcy"
   },
   {
-    "serialNumber": "Wu0lOm5kylP5uOu6md4xmWC3AtQ=",
+    "serialNumber": "RV864VwhzbpUT4KqR1Hr2w==",
     "details": {
       "who": ".",
-      "created": "2017-08-03T15:53:42Z",
-      "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1386894",
-      "name": "StartCom BR SSL ICA",
-      "why": "The two intermediates have issued many certificates that do not comply with the Baseline Requirements."
+      "created": "2017-08-17T17:54:25Z",
+      "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1391095",
+      "name": "Add AC FNMT Usuarios certificate to OneCRL",
+      "why": "https://groups.google.com/forum/#!msg/mozilla.dev.security.policy/Qo1ZNwlYKnY/UrAodnoQBwAJ"
     },
-    "issuerName": "MFoxCzAJBgNVBAYTAkZSMRMwEQYDVQQKEwpDZXJ0aW5vbWlzMRcwFQYDVQQLEw4wMDAyIDQzMzk5ODkwMzEdMBsGA1UEAxMUQ2VydGlub21pcyAtIFJvb3QgQ0E="
-  },
-  {
-    "serialNumber": "Z7mwlz4NA2s+8dnwRzT/RvK9ZZQ=",
-    "details": {
-      "who": ".",
-      "created": "2017-08-03T15:53:42Z",
-      "bug": "https://bugzilla.mozilla.org/show_bug.cgi?id=1386894",
-      "name": "StartCom EV SSL ICA",
-      "why": "The two intermediates have issued many certificates that do not comply with the Baseline Requirements."
-    },
-    "issuerName": "MFoxCzAJBgNVBAYTAkZSMRMwEQYDVQQKEwpDZXJ0aW5vbWlzMRcwFQYDVQQLEw4wMDAyIDQzMzk5ODkwMzEdMBsGA1UEAxMUQ2VydGlub21pcyAtIFJvb3QgQ0E="
+    "issuerName": "MDsxCzAJBgNVBAYTAkVTMREwDwYDVQQKDAhGTk1ULVJDTTEZMBcGA1UECwwQQUMgUkFJWiBGTk1ULVJDTQ=="
   }
 ]}

--- a/summarizeOneCRL/main.go
+++ b/summarizeOneCRL/main.go
@@ -96,11 +96,9 @@ func GetReportLines(conf *config.OneCRLConfig, urlPtr *string) ([]ReportLine, er
 			}
 		}
 
-		// TODO: Decode the serial number into a (readible) hex representation
 		reportLine.SerialNumber, _ = oneCRL.SerialToString(entry.SerialNumber, false, false)
 
 		reportLine.IssuerName, _ = oneCRL.DNToRFC4514(entry.IssuerName)
-		fmt.Printf("blah %s\n",reportLine.IssuerName)
 
 		reportLine.SubjectName = CCADBEntry.CertName
 

--- a/summarizeOneCRL/main.go
+++ b/summarizeOneCRL/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bufio"
+	constraintsx509  "github.com/jcjones/constraintcrypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"github.com/mozilla/OneCRL-Tools/config"
+	"github.com/mozilla/OneCRL-Tools/oneCRL"
+	"github.com/mozilla/OneCRL-Tools/salesforce"
+	"github.com/mozilla/OneCRL-Tools/util"	
+	"os"
+	"strings"
+)
+
+type ReportLine struct {
+	Created string
+	Why string
+	Summary string
+	Bug string
+	BugURL string
+	SerialNumber string
+	IssuerName string
+	SubjectName string
+	NotAfter  string
+}
+
+func GetReportLines(conf *config.OneCRLConfig, urlPtr *string) ([]ReportLine, error) {
+	existing, err := oneCRL.FetchExistingRecords(conf.KintoCollectionURL + "/records")
+	reportLines := make([]ReportLine, 0)
+
+	revokedCerts, err := salesforce.FetchRevokedCertInfoFrom(*urlPtr)
+
+	revocationInfoToCCADBEntry := make(map[string] salesforce.RevokedCertInfo)
+	for idx, revoked := range revokedCerts {
+		// make a map of issuer/serial to revoked
+		certData, err:= salesforce.CertDataFromSalesforcePEM(revoked.PEM)
+		if err != nil {
+			fmt.Printf("(%d, %s, %s) can't decode PEM %s\n%v\n", idx, revoked.CSN, revoked.CertName, revoked.PEM, revoked)
+			continue
+		}
+
+		cert, err := constraintsx509.ParseCertificate(certData)
+		if err != nil {
+			fmt.Printf("(%s, %s) could not parse cert\n", revoked.CSN, revoked.CertName)
+			continue
+		}
+
+		issuerString := base64.StdEncoding.EncodeToString(cert.RawIssuer)
+		serialBytes, err := asn1.Marshal(cert.SerialNumber)
+
+		if err != nil {
+			fmt.Printf("(%s, %s) could not marshal serial number\n", revoked.CSN, revoked.CertName)
+			continue
+		}
+
+		serialString := base64.StdEncoding.EncodeToString(serialBytes[2:])
+		
+		if false {
+			fmt.Printf("Look! %s %s\n", issuerString, serialString);
+		}
+
+		revocationInfoToCCADBEntry[oneCRL.StringFromIssuerSerial(issuerString, serialString)] = revoked
+	}
+
+	if err != nil  {
+		return reportLines, err
+	}
+
+	bugsOfInterest := make([]string, 0)
+
+	for _, entry := range existing.Data {
+		reportLine:= ReportLine{}
+		// TODO: Parse date, make it human readible?
+		reportLine.Created = entry.Details.Created
+		reportLine.Why = entry.Details.Why
+		// if there's no "why" detail in OneCRL, get the reason info from CCADB
+		if 1 >= len(entry.Details.Why) {
+			reportLine.Why = revocationInfoToCCADBEntry[oneCRL.StringFromIssuerSerial(entry.IssuerName, entry.SerialNumber)].Reason
+		}
+
+		reportLine.Bug = entry.Details.Bug
+
+		// attempt to parse out URL parts if it's an URL
+		if 0 == strings.Index(strings.ToUpper(entry.Details.Bug), "HTTPS://") {
+			reportLine.BugURL = entry.Details.Bug
+			// if we can parse out the actual bug string, do so
+			bugURLParts := strings.Split(entry.Details.Bug, "?id=")
+			if len(bugURLParts) == 2 {
+				reportLine.Bug = bugURLParts[1]
+			}
+		}
+
+		// collect the bug number for subsequent summary addition
+		if 0 != len(reportLine.Bug) {
+			bugsOfInterest = append(bugsOfInterest, reportLine.Bug)
+		}
+
+		reportLines = append(reportLines, reportLine)
+	}
+
+	searchResponse, err := bugs.GetBugData(bugsOfInterest, conf)
+	if nil != err {
+		return reportLines, err
+	}
+
+	bugMap := make(map[string] bugs.BugData)
+
+	for _, bug := range(searchResponse.Bugs) {
+		bugMap[fmt.Sprintf("%d", bug.Id)] = bug
+	}
+
+	// loop over the report lines and fill in the summary from the bug
+	for _, reportLine := range(reportLines) {
+		reportLine.Summary = bugMap[reportLine.Bug].Summary
+	}
+
+	return reportLines, nil
+}
+
+func renderToHTML(reportLines []ReportLine, filename string) {
+	f, err := os.Create(filename)
+	if nil != err {
+		panic(err)
+	}
+
+	w := bufio.NewWriter(f)
+
+	defer f.Close()
+	w.WriteString("<html><table>\n")
+	w.WriteString("<tr>")
+	w.WriteString("<td>Created</td>")
+	w.WriteString("<td>Why</td>")
+	w.WriteString("<td>Summary</td>")
+	w.WriteString("<td>Bug</td>")
+	w.WriteString("<td>Serial number</td>")
+	w.WriteString("<td>Issuer name</td>")
+	w.WriteString("<td>Subject name</td>")
+	w.WriteString("<td>Not after</td>")
+	w.WriteString("</tr>\n")
+	
+	for _, reportLine := range(reportLines) {
+		w.WriteString("<tr>")
+		w.WriteString(fmt.Sprintf("<td>%s</td>", reportLine.Created))
+		w.WriteString(fmt.Sprintf("<td>%s</td>", reportLine.Why))
+		w.WriteString(fmt.Sprintf("<td>%s</td>", reportLine.Summary))
+		w.WriteString(fmt.Sprintf("<td>%s</td>", reportLine.Bug))
+		w.WriteString(fmt.Sprintf("<td>%s</td>", reportLine.SerialNumber))
+		w.WriteString(fmt.Sprintf("<td>%s</td>", reportLine.IssuerName))
+		w.WriteString("<td>Subject name</td>")
+		w.WriteString("<td>Not after</td>")
+		w.WriteString("</tr>\n")
+	}
+	
+	w.WriteString("</table></html>\n")
+
+	w.Flush()
+}
+
+func main() {
+	urlPtr := flag.String("url", "https://ccadb-public.secure.force.com/mozilla/PublicIntermediateCertsRevokedWithPEMCSV", "the URL of the salesforce data")
+	typePtr := flag.String("type", "html", "the type of report to generate")
+	outFilePtr := flag.String("outfile", "report", "the filename of the report to create")
+	
+	config.DefineFlags()
+	flag.Parse()
+	conf := config.GetConfig()
+
+	reportLines, err := GetReportLines(conf, urlPtr)
+	if nil != err {
+		panic(err)
+	}
+
+	// render the report
+	if "HTML" == strings.ToUpper(*typePtr) {
+		renderToHTML(reportLines, *outFilePtr)
+	}
+}

--- a/util/bugs.go
+++ b/util/bugs.go
@@ -139,7 +139,6 @@ func GetBugData(bugNumStrings []string, conf *config.OneCRLConfig) (SearchRespon
 	}
 	// TODO: we should appropriately escape the bug number and fields
 	getUrl := fmt.Sprintf(conf.BugzillaBase + "/rest/bug?id=%s&include_fields=%s", bugNumString, getBugDataIncludeFields)
-	fmt.Printf("get bug URL is %s\n", getUrl)
 
 	getReq, err := http.NewRequest("GET", getUrl, nil)
 


### PR DESCRIPTION
The changes to oneCRL.go are obsolete (assuming we merge pr #68), but other than that, this does what Gerv asked for (some tidying may be required).