### PR TITLE
Allow Salesforce2OneCRL-scheduler to build specific git refs.

### DIFF
--- a/tools/Salesforce2OneCRL-scheduler/Makefile
+++ b/tools/Salesforce2OneCRL-scheduler/Makefile
@@ -1,6 +1,6 @@
 build:
 	chmod +x scheduler.py
-	go get -u github.com/mozilla/OneCRL-Tools/salesforce2OneCRL
+	go install github.com/mozilla/OneCRL-Tools/salesforce2OneCRL
 	zip -jr ccadb_scheduler.zip scheduler.py .config.yml $(GOPATH)/bin/salesforce2OneCRL
 clean:
 	rm ccadb_scheduler.zip


### PR DESCRIPTION
Requesting this on recommendation from @oremj:

Alter the makefile to go install instead of go get -u. The way it is now it builds master no matter what ref is currently checked out.