### PR TITLE
added server mode to the certdata.txt diff ccadb tool

### DIFF
--- a/cmd/certdataDiffCCADB/Godeps/Godeps.json
+++ b/cmd/certdataDiffCCADB/Godeps/Godeps.json
@@ -4,6 +4,14 @@
 	"GodepVersion": "v79",
 	"Deps": [
 		{
+			"ImportPath": "github.com/hashicorp/golang-lru",
+			"Rev": "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
+		},
+		{
+			"ImportPath": "github.com/hashicorp/golang-lru/simplelru",
+			"Rev": "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
+		},
+		{
 			"ImportPath": "github.com/mozilla/OneCRL-Tools/ccadb",
 			"Comment": "stable-41-gab5f27a",
 			"Rev": "ab5f27a61690218a54c4f58bd4a4f275e8022365"
@@ -17,6 +25,16 @@
 			"ImportPath": "github.com/mozilla/OneCRL-Tools/certdataDiffCCADB",
 			"Comment": "stable-41-gab5f27a",
 			"Rev": "ab5f27a61690218a54c4f58bd4a4f275e8022365"
+		},
+		{
+			"ImportPath": "github.com/throttled/throttled",
+			"Comment": "v2.1.0-2-g8bde2fa",
+			"Rev": "8bde2fa9734170ec54f69fd1009ad124f236f5fd"
+		},
+		{
+			"ImportPath": "github.com/throttled/throttled/store/memstore",
+			"Comment": "v2.1.0-2-g8bde2fa",
+			"Rev": "8bde2fa9734170ec54f69fd1009ad124f236f5fd"
 		}
 	]
 }

--- a/cmd/certdataDiffCCADB/Godeps/Godeps.json
+++ b/cmd/certdataDiffCCADB/Godeps/Godeps.json
@@ -1,0 +1,22 @@
+{
+	"ImportPath": "github.com/christopher-henderson/OneCRL-Tools/cmd/certdataDiffCCADB",
+	"GoVersion": "go1.9",
+	"GodepVersion": "v79",
+	"Deps": [
+		{
+			"ImportPath": "github.com/mozilla/OneCRL-Tools/ccadb",
+			"Comment": "stable-41-gab5f27a",
+			"Rev": "ab5f27a61690218a54c4f58bd4a4f275e8022365"
+		},
+		{
+			"ImportPath": "github.com/mozilla/OneCRL-Tools/certdata",
+			"Comment": "stable-41-gab5f27a",
+			"Rev": "ab5f27a61690218a54c4f58bd4a4f275e8022365"
+		},
+		{
+			"ImportPath": "github.com/mozilla/OneCRL-Tools/certdataDiffCCADB",
+			"Comment": "stable-41-gab5f27a",
+			"Rev": "ab5f27a61690218a54c4f58bd4a4f275e8022365"
+		}
+	]
+}

--- a/cmd/certdataDiffCCADB/Godeps/Readme
+++ b/cmd/certdataDiffCCADB/Godeps/Readme
@@ -1,0 +1,5 @@
+This directory tree is generated automatically by godep.
+
+Please do not edit.
+
+See https://github.com/tools/godep for more information.

--- a/cmd/certdataDiffCCADB/Procfile
+++ b/cmd/certdataDiffCCADB/Procfile
@@ -1,0 +1,1 @@
+web: certdataDiffCCADB --serve

--- a/cmd/certdataDiffCCADB/deploy_to_heroku.sh
+++ b/cmd/certdataDiffCCADB/deploy_to_heroku.sh
@@ -1,0 +1,10 @@
+#/usr/bin/env bash
+
+# This script is for deploying the certdataDiffCCADB tool to Heroku.
+#
+# Heroku DEMANDS that all applications be at the root of the project.
+# Of course that is not the case here, so let's do something like
+# use the subtree module to push to Heroku.
+#
+# You need to to be in the root of the repo in order to run this.
+git subtree push --prefix cmd/certdataDiffCCADB heroku master

--- a/cmd/certdataDiffCCADB/main.go
+++ b/cmd/certdataDiffCCADB/main.go
@@ -5,24 +5,15 @@
 package main
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/json"
-	"encoding/pem"
 	"flag"
 	"fmt"
 	"io"
 	"log"
-	"math/big"
-	"net"
 	"net/http"
 	"os"
 	"path"
 	"sync"
-	"time"
 
 	"github.com/mozilla/OneCRL-Tools/ccadb"
 	"github.com/mozilla/OneCRL-Tools/certdata"
@@ -34,14 +25,6 @@ const (
 	matched            = "matched.json"
 	unmatchedTrusted   = "unmatchedTrusted.json"
 	unmatchedUntrusted = "unmatchedUntrusted.json"
-)
-
-// Constants for generating and self signing a TLS cert for server mode.
-const (
-	CertDir = "/tmp"
-	Private = "private.pem"
-	Public  = "public.pem"
-	Cert    = "cert.pem"
 )
 
 var certdataURL string
@@ -56,12 +39,6 @@ var unmatchedTrustPath string
 var unmatchedUntrustedPath string
 
 var serverMode bool
-var addr string
-var port string
-var encrypt bool
-var public string
-var private string
-var cert string
 
 func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
@@ -71,17 +48,11 @@ func init() {
 	flag.StringVar(&ccadbURL, "ccadburl", ccadb.URL, "URL to CCADB report file.")
 	flag.StringVar(&outDir, "o", "", "Path to the output directory.")
 	flag.BoolVar(&serverMode, "serve", false, "Start in server mode.")
-	flag.StringVar(&addr, "address", "127.0.0.1", "Address to listen on while in server mode.")
-	flag.StringVar(&port, "port", "1443", "Port to listen on while in server mode.")
 	flag.Parse()
 
 	matchedPath = path.Join(outDir, matched)
 	unmatchedTrustPath = path.Join(outDir, unmatchedTrusted)
 	unmatchedUntrustedPath = path.Join(outDir, unmatchedUntrusted)
-
-	public = path.Join(CertDir, Public)
-	private = path.Join(CertDir, Private)
-	cert = path.Join(CertDir, Cert)
 }
 
 // Functions used for single run mode.
@@ -173,92 +144,6 @@ func parse(src func() io.ReadCloser, parser func(io.Reader) ([]*certdataDiffCCAD
 
 // Functions used for server mode.
 
-// CertTemplate generates a bare minimum template use for x509.CreateCertificate.
-// Credit to https://ericchiang.github.io/post/go-tls/ for saving a lot of time figuring out
-// the bare minimum required.
-func CertTemplate() (*x509.Certificate, error) {
-	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
-	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
-	if err != nil {
-		return nil, err
-	}
-
-	tmpl := x509.Certificate{
-		SerialNumber:          serialNumber,
-		Subject:               pkix.Name{Organization: []string{"Mozilla"}},
-		SignatureAlgorithm:    x509.ECDSAWithSHA384,
-		NotBefore:             time.Now(),
-		NotAfter:              time.Now().Add(time.Hour * 24 * 31 * 12 * 100), // Why not 100 years?
-		BasicConstraintsValid: true,
-	}
-	tmpl.IsCA = false
-	tmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
-	tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
-	tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
-	return &tmpl, nil
-}
-
-// GenerateTLSCert generates an ECDSA key pair over a P384 curve, as well as a
-// self signed certificate, and writes the encoded PEMs to the provided file paths.
-//
-// Many - MANY - erros may occur. This function logs and exits on any errors.
-func GenerateTLSCertOrDie(publicName, privateName, certName string) {
-	// Generate an ECDSA key pair.
-	private, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-	if err != nil {
-		log.Fatal(err)
-	}
-	public := private.Public()
-	// CreateCertificate requires that a "template" be given, so generate an empty cert object
-	// with the basic required fields.
-	template, err := CertTemplate()
-	if err != nil {
-		log.Fatal(err)
-	}
-	// Self Sign.
-	cert, err := x509.CreateCertificate(rand.Reader, template, template, public, private)
-	if err != nil {
-		log.Fatal(err)
-	}
-	// Marshal in memory PEMs to bytes.
-	privKey, err := x509.MarshalECPrivateKey(private)
-	if err != nil {
-		log.Fatal(err)
-	}
-	pubKey, err := x509.MarshalPKIXPublicKey(public)
-	if err != nil {
-		log.Fatal(err)
-	}
-	// Encode and write the key pair and self signed cert to disk.
-	privF, err := os.Create(privateName)
-	defer privF.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-	pubF, err := os.Create(publicName)
-	defer pubF.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-	certF, err := os.Create(certName)
-	defer certF.Close()
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = pem.Encode(privF, &pem.Block{"EC PRIVATE KEY", make(map[string]string, 0), privKey})
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = pem.Encode(pubF, &pem.Block{"EC PUBLIC KEY", make(map[string]string, 0), pubKey})
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = pem.Encode(certF, &pem.Block{"CERTIFICATE", make(map[string]string, 0), cert})
-	if err != nil {
-		log.Fatal(err)
-	}
-}
-
 // SimpleEntry is a subset of the certdataDiffCCADB.Entry use to provide a simpler
 // view of the certdata file while in server mode.
 type SimpleEntry struct {
@@ -270,6 +155,12 @@ type SimpleEntry struct {
 
 // ListCertdata returns to the client a JSON array of SimpleEntry
 func ListCertdata(w http.ResponseWriter, req *http.Request) {
+	defer func() {
+		if err := recover(); err != nil {
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write([]byte(fmt.Sprintf("%v\n", err)))
+		}
+	}()
 	q := req.URL.Query()
 	url := certdataURL
 	if u, ok := q["url"]; ok && len(u) > 0 {
@@ -278,17 +169,17 @@ func ListCertdata(w http.ResponseWriter, req *http.Request) {
 	log.Printf("ListCertdata, IP: %v, certdata.txt URL: %v\n", req.RemoteAddr, url)
 	stream, err := getFromURL(url)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintln(err.Error())))
 		log.Printf("ListCertdata, IP: %v, Error: %v\n", req.RemoteAddr, err)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	defer stream.Close()
 	c, err := certdata.ParseToNormalizedForm(stream)
 	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintln(err.Error())))
 		log.Printf("ListCertdata, IP: %v, Error: %v\n", req.RemoteAddr, err)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
 	resp := make([]SimpleEntry, len(c))
@@ -296,16 +187,25 @@ func ListCertdata(w http.ResponseWriter, req *http.Request) {
 		resp = append(resp, SimpleEntry{e.PEM, e.Fingerprint, e.TrustEmail, e.TrustWeb})
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
 		w.Write([]byte(fmt.Sprintln(err.Error())))
 		log.Printf("ListCertdata, IP: %v, Error: %v\n", req.RemoteAddr, err)
+		w.WriteHeader(http.StatusBadRequest)
 		return
 	}
-	w.WriteHeader(http.StatusOK)
+}
+
+// Runner function for starting the server.
+func serve() {
+	log.Println("Starting in server mode.")
+	// Add handlers.
+	http.HandleFunc("/certdata", ListCertdata)
+	// Start up the server.
+	port := fmt.Sprintf(":%v", os.Getenv("PORT"))
+	log.Printf("Listening on port %v\n", port)
+	log.Fatal(http.ListenAndServe(port, nil))
 }
 
 // Runner functions for either single run mode or server mode.
-
 func singleRun() {
 	cdResult := make(chan []*certdataDiffCCADB.Entry)
 	CCADBResult := make(chan []*certdataDiffCCADB.Entry)
@@ -323,20 +223,6 @@ func singleRun() {
 	go writeJSON(unmatchedT, unmatchedTrustPath, wg)
 	go writeJSON(unmatchedUT, unmatchedUntrustedPath, wg)
 	wg.Wait()
-}
-
-func serve() {
-	log.Println("Starting in server mode.")
-	// Add handlers.
-	http.HandleFunc("/hello", ListCertdata)
-	// Encrypt, but we don't particularly need authetication,
-	// so self signed cert it is.
-	log.Printf("Generating new TLS certificate.")
-	GenerateTLSCertOrDie(public, private, cert)
-	// Start up the server.
-	address := fmt.Sprintf("%v:%v", addr, port)
-	log.Printf("Listening on %v\n", address)
-	log.Fatal(http.ListenAndServeTLS(address, cert, private, nil))
 }
 
 func main() {

--- a/cmd/certdataDiffCCADB/main.go
+++ b/cmd/certdataDiffCCADB/main.go
@@ -5,14 +5,24 @@
 package main
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"flag"
+	"fmt"
 	"io"
 	"log"
+	"math/big"
+	"net"
 	"net/http"
 	"os"
 	"path"
 	"sync"
+	"time"
 
 	"github.com/mozilla/OneCRL-Tools/ccadb"
 	"github.com/mozilla/OneCRL-Tools/certdata"
@@ -26,6 +36,14 @@ const (
 	unmatchedUntrusted = "unmatchedUntrusted.json"
 )
 
+// Constants for generating and self signing a TLS cert for server mode.
+const (
+	CertDir = "/tmp"
+	Private = "private.pem"
+	Public  = "public.pem"
+	Cert    = "cert.pem"
+)
+
 var certdataURL string
 var ccadbURL string
 var certdataPath string
@@ -37,6 +55,14 @@ var matchedPath string
 var unmatchedTrustPath string
 var unmatchedUntrustedPath string
 
+var serverMode bool
+var addr string
+var port string
+var encrypt bool
+var public string
+var private string
+var cert string
+
 func init() {
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 	flag.StringVar(&certdataPath, "cd", "", "Path to certdata.txt")
@@ -44,12 +70,21 @@ func init() {
 	flag.StringVar(&ccadbPath, "ccadb", "", "Path to CCADB report file.")
 	flag.StringVar(&ccadbURL, "ccadburl", ccadb.URL, "URL to CCADB report file.")
 	flag.StringVar(&outDir, "o", "", "Path to the output directory.")
+	flag.BoolVar(&serverMode, "serve", false, "Start in server mode.")
+	flag.StringVar(&addr, "address", "127.0.0.1", "Address to listen on while in server mode.")
+	flag.StringVar(&port, "port", "1443", "Port to listen on while in server mode.")
 	flag.Parse()
 
 	matchedPath = path.Join(outDir, matched)
 	unmatchedTrustPath = path.Join(outDir, unmatchedTrusted)
 	unmatchedUntrustedPath = path.Join(outDir, unmatchedUntrusted)
+
+	public = path.Join(CertDir, Public)
+	private = path.Join(CertDir, Private)
+	cert = path.Join(CertDir, Cert)
 }
+
+// Functions used for single run mode.
 
 // CCCADBReader constructs an io.ReaderCloser depending on the results
 // of parsing the CLI flags. The presence of a filepath will return an io.ReadCloser
@@ -67,11 +102,11 @@ func CCADBReader() io.ReadCloser {
 	} else {
 		log.Printf("Loading CCADB data from %s\n", ccadbURL)
 		// get the stream from URL
-		r, err := http.Get(ccadbURL)
+		r, err := getFromURL(ccadbURL)
 		if err != nil {
 			log.Fatal("Problem fetching CCADB data from URL %s\n", err)
 		}
-		return r.Body
+		return r
 	}
 }
 
@@ -90,13 +125,21 @@ func CertdataReader() io.ReadCloser {
 		return stream
 	} else {
 		log.Printf("Loading certdata.txt data from %s\n", certdataURL)
+		r, err := getFromURL(certdataURL)
 		// get the stream from URL
-		r, err := http.Get(certdataURL)
 		if err != nil {
 			log.Fatal("Problem fetching certdata.txt data from URL %s\n", err)
 		}
-		return r.Body
+		return r
 	}
+}
+
+func getFromURL(url string) (io.ReadCloser, error) {
+	r, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	return r.Body, nil
 }
 
 func writeJSON(v interface{}, fname string, wg *sync.WaitGroup) {
@@ -128,7 +171,142 @@ func parse(src func() io.ReadCloser, parser func(io.Reader) ([]*certdataDiffCCAD
 	out <- result
 }
 
-func main() {
+// Functions used for server mode.
+
+// CertTemplate generates a bare minimum template use for x509.CreateCertificate.
+// Credit to https://ericchiang.github.io/post/go-tls/ for saving a lot of time figuring out
+// the bare minimum required.
+func CertTemplate() (*x509.Certificate, error) {
+	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, err
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber:          serialNumber,
+		Subject:               pkix.Name{Organization: []string{"Mozilla"}},
+		SignatureAlgorithm:    x509.ECDSAWithSHA384,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour * 24 * 31 * 12 * 100), // Why not 100 years?
+		BasicConstraintsValid: true,
+	}
+	tmpl.IsCA = false
+	tmpl.KeyUsage = x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature
+	tmpl.ExtKeyUsage = []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}
+	tmpl.IPAddresses = []net.IP{net.ParseIP("127.0.0.1")}
+	return &tmpl, nil
+}
+
+// GenerateTLSCert generates an ECDSA key pair over a P384 curve, as well as a
+// self signed certificate, and writes the encoded PEMs to the provided file paths.
+//
+// Many - MANY - erros may occur. This function logs and exits on any errors.
+func GenerateTLSCertOrDie(publicName, privateName, certName string) {
+	// Generate an ECDSA key pair.
+	private, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		log.Fatal(err)
+	}
+	public := private.Public()
+	// CreateCertificate requires that a "template" be given, so generate an empty cert object
+	// with the basic required fields.
+	template, err := CertTemplate()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Self Sign.
+	cert, err := x509.CreateCertificate(rand.Reader, template, template, public, private)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Marshal in memory PEMs to bytes.
+	privKey, err := x509.MarshalECPrivateKey(private)
+	if err != nil {
+		log.Fatal(err)
+	}
+	pubKey, err := x509.MarshalPKIXPublicKey(public)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Encode and write the key pair and self signed cert to disk.
+	privF, err := os.Create(privateName)
+	defer privF.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	pubF, err := os.Create(publicName)
+	defer pubF.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	certF, err := os.Create(certName)
+	defer certF.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = pem.Encode(privF, &pem.Block{"EC PRIVATE KEY", make(map[string]string, 0), privKey})
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = pem.Encode(pubF, &pem.Block{"EC PUBLIC KEY", make(map[string]string, 0), pubKey})
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = pem.Encode(certF, &pem.Block{"CERTIFICATE", make(map[string]string, 0), cert})
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// SimpleEntry is a subset of the certdataDiffCCADB.Entry use to provide a simpler
+// view of the certdata file while in server mode.
+type SimpleEntry struct {
+	PEM         string `json:"PEM"`
+	Fingerprint string `json:"sha256"`
+	TrustWeb    bool   `json:"trustWeb"`
+	TrustEmail  bool   `json:"trustEmail"`
+}
+
+// ListCertdata returns to the client a JSON array of SimpleEntry
+func ListCertdata(w http.ResponseWriter, req *http.Request) {
+	q := req.URL.Query()
+	url := certdataURL
+	if u, ok := q["url"]; ok && len(u) > 0 {
+		url = u[0]
+	}
+	log.Printf("ListCertdata, IP: %v, certdata.txt URL: %v\n", req.RemoteAddr, url)
+	stream, err := getFromURL(url)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintln(err.Error())))
+		log.Printf("ListCertdata, IP: %v, Error: %v\n", req.RemoteAddr, err)
+		return
+	}
+	defer stream.Close()
+	c, err := certdata.ParseToNormalizedForm(stream)
+	if err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintln(err.Error())))
+		log.Printf("ListCertdata, IP: %v, Error: %v\n", req.RemoteAddr, err)
+		return
+	}
+	resp := make([]SimpleEntry, len(c))
+	for _, e := range c {
+		resp = append(resp, SimpleEntry{e.PEM, e.Fingerprint, e.TrustEmail, e.TrustWeb})
+	}
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(fmt.Sprintln(err.Error())))
+		log.Printf("ListCertdata, IP: %v, Error: %v\n", req.RemoteAddr, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// Runner functions for either single run mode or server mode.
+
+func singleRun() {
 	cdResult := make(chan []*certdataDiffCCADB.Entry)
 	CCADBResult := make(chan []*certdataDiffCCADB.Entry)
 	go parse(CertdataReader, certdata.ParseToNormalizedForm, cdResult)
@@ -145,4 +323,26 @@ func main() {
 	go writeJSON(unmatchedT, unmatchedTrustPath, wg)
 	go writeJSON(unmatchedUT, unmatchedUntrustedPath, wg)
 	wg.Wait()
+}
+
+func serve() {
+	log.Println("Starting in server mode.")
+	// Add handlers.
+	http.HandleFunc("/hello", ListCertdata)
+	// Encrypt, but we don't particularly need authetication,
+	// so self signed cert it is.
+	log.Printf("Generating new TLS certificate.")
+	GenerateTLSCertOrDie(public, private, cert)
+	// Start up the server.
+	address := fmt.Sprintf("%v:%v", addr, port)
+	log.Printf("Listening on %v\n", address)
+	log.Fatal(http.ListenAndServeTLS(address, cert, private, nil))
+}
+
+func main() {
+	if serverMode {
+		serve()
+	} else {
+		singleRun()
+	}
 }

--- a/cmd/certdataDiffCCADB/main.go
+++ b/cmd/certdataDiffCCADB/main.go
@@ -108,7 +108,12 @@ func CertdataReader() io.ReadCloser {
 }
 
 func getFromURL(url string) (io.ReadCloser, error) {
-	r, err := http.Get(url)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("X-Automated-Tool", `https://github.com/mozilla/OneCRL-Tools certdataDiffCCADB"`)
+	r, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -157,7 +162,6 @@ type SimpleEntry struct {
 
 // ListCertdata returns to the client a JSON array of SimpleEntry
 func ListCertdata(w http.ResponseWriter, req *http.Request) {
-	w.Header().Set("X-Automated-Tool", "https://github.com/mozilla/OneCRL-Tools certdataDiffCCADB")
 	defer func() {
 		if err := recover(); err != nil {
 			w.WriteHeader(http.StatusBadGateway)

--- a/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/.gitignore
+++ b/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/.gitignore
@@ -1,0 +1,23 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test

--- a/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/2q.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/2q.go
@@ -1,0 +1,212 @@
+package lru
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+const (
+	// Default2QRecentRatio is the ratio of the 2Q cache dedicated
+	// to recently added entries that have only been accessed once.
+	Default2QRecentRatio = 0.25
+
+	// Default2QGhostEntries is the default ratio of ghost
+	// entries kept to track entries recently evicted
+	Default2QGhostEntries = 0.50
+)
+
+// TwoQueueCache is a thread-safe fixed size 2Q cache.
+// 2Q is an enhancement over the standard LRU cache
+// in that it tracks both frequently and recently used
+// entries separately. This avoids a burst in access to new
+// entries from evicting frequently used entries. It adds some
+// additional tracking overhead to the standard LRU cache, and is
+// computationally about 2x the cost, and adds some metadata over
+// head. The ARCCache is similar, but does not require setting any
+// parameters.
+type TwoQueueCache struct {
+	size       int
+	recentSize int
+
+	recent      *simplelru.LRU
+	frequent    *simplelru.LRU
+	recentEvict *simplelru.LRU
+	lock        sync.RWMutex
+}
+
+// New2Q creates a new TwoQueueCache using the default
+// values for the parameters.
+func New2Q(size int) (*TwoQueueCache, error) {
+	return New2QParams(size, Default2QRecentRatio, Default2QGhostEntries)
+}
+
+// New2QParams creates a new TwoQueueCache using the provided
+// parameter values.
+func New2QParams(size int, recentRatio float64, ghostRatio float64) (*TwoQueueCache, error) {
+	if size <= 0 {
+		return nil, fmt.Errorf("invalid size")
+	}
+	if recentRatio < 0.0 || recentRatio > 1.0 {
+		return nil, fmt.Errorf("invalid recent ratio")
+	}
+	if ghostRatio < 0.0 || ghostRatio > 1.0 {
+		return nil, fmt.Errorf("invalid ghost ratio")
+	}
+
+	// Determine the sub-sizes
+	recentSize := int(float64(size) * recentRatio)
+	evictSize := int(float64(size) * ghostRatio)
+
+	// Allocate the LRUs
+	recent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	frequent, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	recentEvict, err := simplelru.NewLRU(evictSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the cache
+	c := &TwoQueueCache{
+		size:        size,
+		recentSize:  recentSize,
+		recent:      recent,
+		frequent:    frequent,
+		recentEvict: recentEvict,
+	}
+	return c, nil
+}
+
+func (c *TwoQueueCache) Get(key interface{}) (interface{}, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if this is a frequent value
+	if val, ok := c.frequent.Get(key); ok {
+		return val, ok
+	}
+
+	// If the value is contained in recent, then we
+	// promote it to frequent
+	if val, ok := c.recent.Peek(key); ok {
+		c.recent.Remove(key)
+		c.frequent.Add(key, val)
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+func (c *TwoQueueCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is frequently used already,
+	// and just update the value
+	if c.frequent.Contains(key) {
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Check if the value is recently used, and promote
+	// the value into the frequent list
+	if c.recent.Contains(key) {
+		c.recent.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// If the value was recently evicted, add it to the
+	// frequently used list
+	if c.recentEvict.Contains(key) {
+		c.ensureSpace(true)
+		c.recentEvict.Remove(key)
+		c.frequent.Add(key, value)
+		return
+	}
+
+	// Add to the recently seen list
+	c.ensureSpace(false)
+	c.recent.Add(key, value)
+	return
+}
+
+// ensureSpace is used to ensure we have space in the cache
+func (c *TwoQueueCache) ensureSpace(recentEvict bool) {
+	// If we have space, nothing to do
+	recentLen := c.recent.Len()
+	freqLen := c.frequent.Len()
+	if recentLen+freqLen < c.size {
+		return
+	}
+
+	// If the recent buffer is larger than
+	// the target, evict from there
+	if recentLen > 0 && (recentLen > c.recentSize || (recentLen == c.recentSize && !recentEvict)) {
+		k, _, _ := c.recent.RemoveOldest()
+		c.recentEvict.Add(k, nil)
+		return
+	}
+
+	// Remove from the frequent list otherwise
+	c.frequent.RemoveOldest()
+}
+
+func (c *TwoQueueCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.recent.Len() + c.frequent.Len()
+}
+
+func (c *TwoQueueCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.frequent.Keys()
+	k2 := c.recent.Keys()
+	return append(k1, k2...)
+}
+
+func (c *TwoQueueCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.frequent.Remove(key) {
+		return
+	}
+	if c.recent.Remove(key) {
+		return
+	}
+	if c.recentEvict.Remove(key) {
+		return
+	}
+}
+
+func (c *TwoQueueCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.recent.Purge()
+	c.frequent.Purge()
+	c.recentEvict.Purge()
+}
+
+func (c *TwoQueueCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.frequent.Contains(key) || c.recent.Contains(key)
+}
+
+func (c *TwoQueueCache) Peek(key interface{}) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.frequent.Peek(key); ok {
+		return val, ok
+	}
+	return c.recent.Peek(key)
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/LICENSE
+++ b/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/LICENSE
@@ -1,0 +1,362 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.

--- a/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/README.md
+++ b/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/README.md
@@ -1,0 +1,25 @@
+golang-lru
+==========
+
+This provides the `lru` package which implements a fixed-size
+thread safe LRU cache. It is based on the cache in Groupcache.
+
+Documentation
+=============
+
+Full docs are available on [Godoc](http://godoc.org/github.com/hashicorp/golang-lru)
+
+Example
+=======
+
+Using the LRU is very simple:
+
+```go
+l, _ := New(128)
+for i := 0; i < 256; i++ {
+    l.Add(i, nil)
+}
+if l.Len() != 128 {
+    panic(fmt.Sprintf("bad len: %v", l.Len()))
+}
+```

--- a/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/arc.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/arc.go
@@ -1,0 +1,257 @@
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// ARCCache is a thread-safe fixed size Adaptive Replacement Cache (ARC).
+// ARC is an enhancement over the standard LRU cache in that tracks both
+// frequency and recency of use. This avoids a burst in access to new
+// entries from evicting the frequently used older entries. It adds some
+// additional tracking overhead to a standard LRU cache, computationally
+// it is roughly 2x the cost, and the extra memory overhead is linear
+// with the size of the cache. ARC has been patented by IBM, but is
+// similar to the TwoQueueCache (2Q) which requires setting parameters.
+type ARCCache struct {
+	size int // Size is the total capacity of the cache
+	p    int // P is the dynamic preference towards T1 or T2
+
+	t1 *simplelru.LRU // T1 is the LRU for recently accessed items
+	b1 *simplelru.LRU // B1 is the LRU for evictions from t1
+
+	t2 *simplelru.LRU // T2 is the LRU for frequently accessed items
+	b2 *simplelru.LRU // B2 is the LRU for evictions from t2
+
+	lock sync.RWMutex
+}
+
+// NewARC creates an ARC of the given size
+func NewARC(size int) (*ARCCache, error) {
+	// Create the sub LRUs
+	b1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	b2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t1, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+	t2, err := simplelru.NewLRU(size, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Initialize the ARC
+	c := &ARCCache{
+		size: size,
+		p:    0,
+		t1:   t1,
+		b1:   b1,
+		t2:   t2,
+		b2:   b2,
+	}
+	return c, nil
+}
+
+// Get looks up a key's value from the cache.
+func (c *ARCCache) Get(key interface{}) (interface{}, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Ff the value is contained in T1 (recent), then
+	// promote it to T2 (frequent)
+	if val, ok := c.t1.Peek(key); ok {
+		c.t1.Remove(key)
+		c.t2.Add(key, val)
+		return val, ok
+	}
+
+	// Check if the value is contained in T2 (frequent)
+	if val, ok := c.t2.Get(key); ok {
+		return val, ok
+	}
+
+	// No hit
+	return nil, false
+}
+
+// Add adds a value to the cache.
+func (c *ARCCache) Add(key, value interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	// Check if the value is contained in T1 (recent), and potentially
+	// promote it to frequent T2
+	if c.t1.Contains(key) {
+		c.t1.Remove(key)
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if the value is already in T2 (frequent) and update it
+	if c.t2.Contains(key) {
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// recently used list
+	if c.b1.Contains(key) {
+		// T1 set is too small, increase P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b2Len > b1Len {
+			delta = b2Len / b1Len
+		}
+		if c.p+delta >= c.size {
+			c.p = c.size
+		} else {
+			c.p += delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(false)
+		}
+
+		// Remove from B1
+		c.b1.Remove(key)
+
+		// Add the key to the frequently used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Check if this value was recently evicted as part of the
+	// frequently used list
+	if c.b2.Contains(key) {
+		// T2 set is too small, decrease P appropriately
+		delta := 1
+		b1Len := c.b1.Len()
+		b2Len := c.b2.Len()
+		if b1Len > b2Len {
+			delta = b1Len / b2Len
+		}
+		if delta >= c.p {
+			c.p = 0
+		} else {
+			c.p -= delta
+		}
+
+		// Potentially need to make room in the cache
+		if c.t1.Len()+c.t2.Len() >= c.size {
+			c.replace(true)
+		}
+
+		// Remove from B2
+		c.b2.Remove(key)
+
+		// Add the key to the frequntly used list
+		c.t2.Add(key, value)
+		return
+	}
+
+	// Potentially need to make room in the cache
+	if c.t1.Len()+c.t2.Len() >= c.size {
+		c.replace(false)
+	}
+
+	// Keep the size of the ghost buffers trim
+	if c.b1.Len() > c.size-c.p {
+		c.b1.RemoveOldest()
+	}
+	if c.b2.Len() > c.p {
+		c.b2.RemoveOldest()
+	}
+
+	// Add to the recently seen list
+	c.t1.Add(key, value)
+	return
+}
+
+// replace is used to adaptively evict from either T1 or T2
+// based on the current learned value of P
+func (c *ARCCache) replace(b2ContainsKey bool) {
+	t1Len := c.t1.Len()
+	if t1Len > 0 && (t1Len > c.p || (t1Len == c.p && b2ContainsKey)) {
+		k, _, ok := c.t1.RemoveOldest()
+		if ok {
+			c.b1.Add(k, nil)
+		}
+	} else {
+		k, _, ok := c.t2.RemoveOldest()
+		if ok {
+			c.b2.Add(k, nil)
+		}
+	}
+}
+
+// Len returns the number of cached entries
+func (c *ARCCache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Len() + c.t2.Len()
+}
+
+// Keys returns all the cached keys
+func (c *ARCCache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	k1 := c.t1.Keys()
+	k2 := c.t2.Keys()
+	return append(k1, k2...)
+}
+
+// Remove is used to purge a key from the cache
+func (c *ARCCache) Remove(key interface{}) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.t1.Remove(key) {
+		return
+	}
+	if c.t2.Remove(key) {
+		return
+	}
+	if c.b1.Remove(key) {
+		return
+	}
+	if c.b2.Remove(key) {
+		return
+	}
+}
+
+// Purge is used to clear the cache
+func (c *ARCCache) Purge() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.t1.Purge()
+	c.t2.Purge()
+	c.b1.Purge()
+	c.b2.Purge()
+}
+
+// Contains is used to check if the cache contains a key
+// without updating recency or frequency.
+func (c *ARCCache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.t1.Contains(key) || c.t2.Contains(key)
+}
+
+// Peek is used to inspect the cache value of a key
+// without updating recency or frequency.
+func (c *ARCCache) Peek(key interface{}) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	if val, ok := c.t1.Peek(key); ok {
+		return val, ok
+	}
+	return c.t2.Peek(key)
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/lru.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/lru.go
@@ -1,0 +1,114 @@
+// This package provides a simple LRU cache. It is based on the
+// LRU implementation in groupcache:
+// https://github.com/golang/groupcache/tree/master/lru
+package lru
+
+import (
+	"sync"
+
+	"github.com/hashicorp/golang-lru/simplelru"
+)
+
+// Cache is a thread-safe fixed size LRU cache.
+type Cache struct {
+	lru  *simplelru.LRU
+	lock sync.RWMutex
+}
+
+// New creates an LRU of the given size
+func New(size int) (*Cache, error) {
+	return NewWithEvict(size, nil)
+}
+
+// NewWithEvict constructs a fixed size cache with the given eviction
+// callback.
+func NewWithEvict(size int, onEvicted func(key interface{}, value interface{})) (*Cache, error) {
+	lru, err := simplelru.NewLRU(size, simplelru.EvictCallback(onEvicted))
+	if err != nil {
+		return nil, err
+	}
+	c := &Cache{
+		lru: lru,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache
+func (c *Cache) Purge() {
+	c.lock.Lock()
+	c.lru.Purge()
+	c.lock.Unlock()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *Cache) Add(key, value interface{}) bool {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.lru.Add(key, value)
+}
+
+// Get looks up a key's value from the cache.
+func (c *Cache) Get(key interface{}) (interface{}, bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	return c.lru.Get(key)
+}
+
+// Check if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *Cache) Contains(key interface{}) bool {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Contains(key)
+}
+
+// Returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *Cache) Peek(key interface{}) (interface{}, bool) {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Peek(key)
+}
+
+// ContainsOrAdd checks if a key is in the cache  without updating the
+// recent-ness or deleting it for being stale,  and if not, adds the value.
+// Returns whether found and whether an eviction occurred.
+func (c *Cache) ContainsOrAdd(key, value interface{}) (ok, evict bool) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	if c.lru.Contains(key) {
+		return true, false
+	} else {
+		evict := c.lru.Add(key, value)
+		return false, evict
+	}
+}
+
+// Remove removes the provided key from the cache.
+func (c *Cache) Remove(key interface{}) {
+	c.lock.Lock()
+	c.lru.Remove(key)
+	c.lock.Unlock()
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *Cache) RemoveOldest() {
+	c.lock.Lock()
+	c.lru.RemoveOldest()
+	c.lock.Unlock()
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *Cache) Keys() []interface{} {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Keys()
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache) Len() int {
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+	return c.lru.Len()
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/hashicorp/golang-lru/simplelru/lru.go
@@ -1,0 +1,160 @@
+package simplelru
+
+import (
+	"container/list"
+	"errors"
+)
+
+// EvictCallback is used to get a callback when a cache entry is evicted
+type EvictCallback func(key interface{}, value interface{})
+
+// LRU implements a non-thread safe fixed size LRU cache
+type LRU struct {
+	size      int
+	evictList *list.List
+	items     map[interface{}]*list.Element
+	onEvict   EvictCallback
+}
+
+// entry is used to hold a value in the evictList
+type entry struct {
+	key   interface{}
+	value interface{}
+}
+
+// NewLRU constructs an LRU of the given size
+func NewLRU(size int, onEvict EvictCallback) (*LRU, error) {
+	if size <= 0 {
+		return nil, errors.New("Must provide a positive size")
+	}
+	c := &LRU{
+		size:      size,
+		evictList: list.New(),
+		items:     make(map[interface{}]*list.Element),
+		onEvict:   onEvict,
+	}
+	return c, nil
+}
+
+// Purge is used to completely clear the cache
+func (c *LRU) Purge() {
+	for k, v := range c.items {
+		if c.onEvict != nil {
+			c.onEvict(k, v.Value.(*entry).value)
+		}
+		delete(c.items, k)
+	}
+	c.evictList.Init()
+}
+
+// Add adds a value to the cache.  Returns true if an eviction occurred.
+func (c *LRU) Add(key, value interface{}) bool {
+	// Check for existing item
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		ent.Value.(*entry).value = value
+		return false
+	}
+
+	// Add new item
+	ent := &entry{key, value}
+	entry := c.evictList.PushFront(ent)
+	c.items[key] = entry
+
+	evict := c.evictList.Len() > c.size
+	// Verify size not exceeded
+	if evict {
+		c.removeOldest()
+	}
+	return evict
+}
+
+// Get looks up a key's value from the cache.
+func (c *LRU) Get(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		c.evictList.MoveToFront(ent)
+		return ent.Value.(*entry).value, true
+	}
+	return
+}
+
+// Check if a key is in the cache, without updating the recent-ness
+// or deleting it for being stale.
+func (c *LRU) Contains(key interface{}) (ok bool) {
+	_, ok = c.items[key]
+	return ok
+}
+
+// Returns the key value (or undefined if not found) without updating
+// the "recently used"-ness of the key.
+func (c *LRU) Peek(key interface{}) (value interface{}, ok bool) {
+	if ent, ok := c.items[key]; ok {
+		return ent.Value.(*entry).value, true
+	}
+	return nil, ok
+}
+
+// Remove removes the provided key from the cache, returning if the
+// key was contained.
+func (c *LRU) Remove(key interface{}) bool {
+	if ent, ok := c.items[key]; ok {
+		c.removeElement(ent)
+		return true
+	}
+	return false
+}
+
+// RemoveOldest removes the oldest item from the cache.
+func (c *LRU) RemoveOldest() (interface{}, interface{}, bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// GetOldest returns the oldest entry
+func (c *LRU) GetOldest() (interface{}, interface{}, bool) {
+	ent := c.evictList.Back()
+	if ent != nil {
+		kv := ent.Value.(*entry)
+		return kv.key, kv.value, true
+	}
+	return nil, nil, false
+}
+
+// Keys returns a slice of the keys in the cache, from oldest to newest.
+func (c *LRU) Keys() []interface{} {
+	keys := make([]interface{}, len(c.items))
+	i := 0
+	for ent := c.evictList.Back(); ent != nil; ent = ent.Prev() {
+		keys[i] = ent.Value.(*entry).key
+		i++
+	}
+	return keys
+}
+
+// Len returns the number of items in the cache.
+func (c *LRU) Len() int {
+	return c.evictList.Len()
+}
+
+// removeOldest removes the oldest item from the cache.
+func (c *LRU) removeOldest() {
+	ent := c.evictList.Back()
+	if ent != nil {
+		c.removeElement(ent)
+	}
+}
+
+// removeElement is used to remove a given list element from the cache
+func (c *LRU) removeElement(e *list.Element) {
+	c.evictList.Remove(e)
+	kv := e.Value.(*entry)
+	delete(c.items, kv.key)
+	if c.onEvict != nil {
+		c.onEvict(kv.key, kv.value)
+	}
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/LICENSE
+++ b/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/LICENSE
@@ -1,0 +1,364 @@
+Mozilla Public License, version 2.0
+
+1. Definitions
+
+1.1. "Contributor"
+
+     means each individual or legal entity that creates, contributes to the
+     creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+
+     means the combination of the Contributions of others (if any) used by a
+     Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+
+     means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+
+     means Source Code Form to which the initial Contributor has attached the
+     notice in Exhibit A, the Executable Form of such Source Code Form, and
+     Modifications of such Source Code Form, in each case including portions
+     thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+     means
+
+     a. that the initial Contributor has attached the notice described in
+        Exhibit B to the Covered Software; or
+
+     b. that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the terms of
+        a Secondary License.
+
+1.6. "Executable Form"
+
+     means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+
+     means a work that combines Covered Software with other material, in a
+     separate file or files, that is not Covered Software.
+
+1.8. "License"
+
+     means this document.
+
+1.9. "Licensable"
+
+     means having the right to grant, to the maximum extent possible, whether
+     at the time of the initial grant or subsequently, any and all of the
+     rights conveyed by this License.
+
+1.10. "Modifications"
+
+     means any of the following:
+
+     a. any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered Software; or
+
+     b. any new file in Source Code Form that contains any Covered Software.
+
+1.11. "Patent Claims" of a Contributor
+
+      means any patent claim(s), including without limitation, method,
+      process, and apparatus claims, in any patent Licensable by such
+      Contributor that would be infringed, but for the grant of the License,
+      by the making, using, selling, offering for sale, having made, import,
+      or transfer of either its Contributions or its Contributor Version.
+
+1.12. "Secondary License"
+
+      means either the GNU General Public License, Version 2.0, the GNU Lesser
+      General Public License, Version 2.1, the GNU Affero General Public
+      License, Version 3.0, or any later versions of those licenses.
+
+1.13. "Source Code Form"
+
+      means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+
+      means an individual or a legal entity exercising rights under this
+      License. For legal entities, "You" includes any entity that controls, is
+      controlled by, or is under common control with You. For purposes of this
+      definition, "control" means (a) the power, direct or indirect, to cause
+      the direction or management of such entity, whether by contract or
+      otherwise, or (b) ownership of more than fifty percent (50%) of the
+      outstanding shares or beneficial ownership of such entity.
+
+
+2. License Grants and Conditions
+
+2.1. Grants
+
+     Each Contributor hereby grants You a world-wide, royalty-free,
+     non-exclusive license:
+
+     a. under intellectual property rights (other than patent or trademark)
+        Licensable by such Contributor to use, reproduce, make available,
+        modify, display, perform, distribute, and otherwise exploit its
+        Contributions, either on an unmodified basis, with Modifications, or
+        as part of a Larger Work; and
+
+     b. under Patent Claims of such Contributor to make, use, sell, offer for
+        sale, have made, import, and otherwise transfer either its
+        Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+     The licenses granted in Section 2.1 with respect to any Contribution
+     become effective for each Contribution on the date the Contributor first
+     distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+     The licenses granted in this Section 2 are the only rights granted under
+     this License. No additional rights or licenses will be implied from the
+     distribution or licensing of Covered Software under this License.
+     Notwithstanding Section 2.1(b) above, no patent license is granted by a
+     Contributor:
+
+     a. for any code that a Contributor has removed from Covered Software; or
+
+     b. for infringements caused by: (i) Your and any other third party's
+        modifications of Covered Software, or (ii) the combination of its
+        Contributions with other software (except as part of its Contributor
+        Version); or
+
+     c. under Patent Claims infringed by Covered Software in the absence of
+        its Contributions.
+
+     This License does not grant any rights in the trademarks, service marks,
+     or logos of any Contributor (except as may be necessary to comply with
+     the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+     No Contributor makes additional grants as a result of Your choice to
+     distribute the Covered Software under a subsequent version of this
+     License (see Section 10.2) or under the terms of a Secondary License (if
+     permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+     Each Contributor represents that the Contributor believes its
+     Contributions are its original creation(s) or it has sufficient rights to
+     grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+     This License is not intended to limit any rights You have under
+     applicable copyright doctrines of fair use, fair dealing, or other
+     equivalents.
+
+2.7. Conditions
+
+     Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted in
+     Section 2.1.
+
+
+3. Responsibilities
+
+3.1. Distribution of Source Form
+
+     All distribution of Covered Software in Source Code Form, including any
+     Modifications that You create or to which You contribute, must be under
+     the terms of this License. You must inform recipients that the Source
+     Code Form of the Covered Software is governed by the terms of this
+     License, and how they can obtain a copy of this License. You may not
+     attempt to alter or restrict the recipients' rights in the Source Code
+     Form.
+
+3.2. Distribution of Executable Form
+
+     If You distribute Covered Software in Executable Form then:
+
+     a. such Covered Software must also be made available in Source Code Form,
+        as described in Section 3.1, and You must inform recipients of the
+        Executable Form how they can obtain a copy of such Source Code Form by
+        reasonable means in a timely manner, at a charge no more than the cost
+        of distribution to the recipient; and
+
+     b. You may distribute such Executable Form under the terms of this
+        License, or sublicense it under different terms, provided that the
+        license for the Executable Form does not attempt to limit or alter the
+        recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+     You may create and distribute a Larger Work under terms of Your choice,
+     provided that You also comply with the requirements of this License for
+     the Covered Software. If the Larger Work is a combination of Covered
+     Software with a work governed by one or more Secondary Licenses, and the
+     Covered Software is not Incompatible With Secondary Licenses, this
+     License permits You to additionally distribute such Covered Software
+     under the terms of such Secondary License(s), so that the recipient of
+     the Larger Work may, at their option, further distribute the Covered
+     Software under the terms of either this License or such Secondary
+     License(s).
+
+3.4. Notices
+
+     You may not remove or alter the substance of any license notices
+     (including copyright notices, patent notices, disclaimers of warranty, or
+     limitations of liability) contained within the Source Code Form of the
+     Covered Software, except that You may alter any license notices to the
+     extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+     You may choose to offer, and to charge a fee for, warranty, support,
+     indemnity or liability obligations to one or more recipients of Covered
+     Software. However, You may do so only on Your own behalf, and not on
+     behalf of any Contributor. You must make it absolutely clear that any
+     such warranty, support, indemnity, or liability obligation is offered by
+     You alone, and You hereby agree to indemnify every Contributor for any
+     liability incurred by such Contributor as a result of warranty, support,
+     indemnity or liability terms You offer. You may include additional
+     disclaimers of warranty and limitations of liability specific to any
+     jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+
+   If it is impossible for You to comply with any of the terms of this License
+   with respect to some or all of the Covered Software due to statute,
+   judicial order, or regulation then You must: (a) comply with the terms of
+   this License to the maximum extent possible; and (b) describe the
+   limitations and the code they affect. Such description must be placed in a
+   text file included with all distributions of the Covered Software under
+   this License. Except to the extent prohibited by statute or regulation,
+   such description must be sufficiently detailed for a recipient of ordinary
+   skill to be able to understand it.
+
+5. Termination
+
+5.1. The rights granted under this License will terminate automatically if You
+     fail to comply with any of its terms. However, if You become compliant,
+     then the rights granted under this License from a particular Contributor
+     are reinstated (a) provisionally, unless and until such Contributor
+     explicitly and finally terminates Your grants, and (b) on an ongoing
+     basis, if such Contributor fails to notify You of the non-compliance by
+     some reasonable means prior to 60 days after You have come back into
+     compliance. Moreover, Your grants from a particular Contributor are
+     reinstated on an ongoing basis if such Contributor notifies You of the
+     non-compliance by some reasonable means, this is the first time You have
+     received notice of non-compliance with this License from such
+     Contributor, and You become compliant prior to 30 days after Your receipt
+     of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+     infringement claim (excluding declaratory judgment actions,
+     counter-claims, and cross-claims) alleging that a Contributor Version
+     directly or indirectly infringes any patent, then the rights granted to
+     You by any and all Contributors for the Covered Software under Section
+     2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all end user
+     license agreements (excluding distributors and resellers) which have been
+     validly granted by You or Your distributors under this License prior to
+     termination shall survive termination.
+
+6. Disclaimer of Warranty
+
+   Covered Software is provided under this License on an "as is" basis,
+   without warranty of any kind, either expressed, implied, or statutory,
+   including, without limitation, warranties that the Covered Software is free
+   of defects, merchantable, fit for a particular purpose or non-infringing.
+   The entire risk as to the quality and performance of the Covered Software
+   is with You. Should any Covered Software prove defective in any respect,
+   You (not any Contributor) assume the cost of any necessary servicing,
+   repair, or correction. This disclaimer of warranty constitutes an essential
+   part of this License. No use of  any Covered Software is authorized under
+   this License except under this disclaimer.
+
+7. Limitation of Liability
+
+   Under no circumstances and under no legal theory, whether tort (including
+   negligence), contract, or otherwise, shall any Contributor, or anyone who
+   distributes Covered Software as permitted above, be liable to You for any
+   direct, indirect, special, incidental, or consequential damages of any
+   character including, without limitation, damages for lost profits, loss of
+   goodwill, work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses, even if such party shall have been
+   informed of the possibility of such damages. This limitation of liability
+   shall not apply to liability for death or personal injury resulting from
+   such party's negligence to the extent applicable law prohibits such
+   limitation. Some jurisdictions do not allow the exclusion or limitation of
+   incidental or consequential damages, so this exclusion and limitation may
+   not apply to You.
+
+8. Litigation
+
+   Any litigation relating to this License may be brought only in the courts
+   of a jurisdiction where the defendant maintains its principal place of
+   business and such litigation shall be governed by laws of that
+   jurisdiction, without reference to its conflict-of-law provisions. Nothing
+   in this Section shall prevent a party's ability to bring cross-claims or
+   counter-claims.
+
+9. Miscellaneous
+
+   This License represents the complete agreement concerning the subject
+   matter hereof. If any provision of this License is held to be
+   unenforceable, such provision shall be reformed only to the extent
+   necessary to make it enforceable. Any law or regulation which provides that
+   the language of a contract shall be construed against the drafter shall not
+   be used to construe this License against a Contributor.
+
+
+10. Versions of the License
+
+10.1. New Versions
+
+      Mozilla Foundation is the license steward. Except as provided in Section
+      10.3, no one other than the license steward has the right to modify or
+      publish new versions of this License. Each version will be given a
+      distinguishing version number.
+
+10.2. Effect of New Versions
+
+      You may distribute the Covered Software under the terms of the version
+      of the License under which You originally received the Covered Software,
+      or under the terms of any subsequent version published by the license
+      steward.
+
+10.3. Modified Versions
+
+      If you create software not governed by this License, and you want to
+      create a new license for such software, you may create and use a
+      modified version of this License if you rename the license and remove
+      any references to the name of the license steward (except to note that
+      such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+      Licenses If You choose to distribute Source Code Form that is
+      Incompatible With Secondary Licenses under the terms of this version of
+      the License, the notice described in Exhibit B of this License must be
+      attached.
+
+Exhibit A - Source Code Form License Notice
+
+      This Source Code Form is subject to the
+      terms of the Mozilla Public License, v.
+      2.0. If a copy of the MPL was not
+      distributed with this file, You can
+      obtain one at
+      http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular file,
+then You may include the notice in a location (such as a LICENSE file in a
+relevant directory) where a recipient would be likely to look for such a
+notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+
+      This Source Code Form is "Incompatible
+      With Secondary Licenses", as defined by
+      the Mozilla Public License, v. 2.0.
+
+

--- a/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/ccadb/ccadb.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/ccadb/ccadb.go
@@ -1,0 +1,150 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package ccadb
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"io"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/mozilla/OneCRL-Tools/certdataDiffCCADB"
+)
+
+const (
+	URL = "https://ccadb-public.secure.force.com/mozilla/IncludedCACertificateReportPEMCSV"
+
+	CIO  = "Certificate Issuer Organization"
+	CIOU = "Certificate Issuer Organizational Unit"
+	CN   = "Common Name or Certificate Name"
+	CSN  = "Certificate Serial Number"
+	FP   = "SHA-256 Fingerprint"
+	PEM  = "PEM Info"
+	TB   = "Trust Bits"
+
+	TimeFMT = "2006 Jan 01"
+
+	TrustWeb   = "Websites"
+	TrustEmail = "Email"
+)
+
+type Certificate struct {
+	columnMap map[string]int
+	row       []string
+	lineNum   int
+}
+
+func (c *Certificate) Get(attr string) (string, bool) {
+	index, ok := c.columnMap[attr]
+	if !ok {
+		return "", false
+	}
+	return c.row[index], true
+}
+
+func (c *Certificate) ValidFromGMT() (time.Time, error) {
+	t, ok := c.Get("Valid From [GMT]")
+	if !ok {
+		return time.Time{}, errors.New("ValidFromGMT not found.")
+	}
+	return time.Parse(TimeFMT, t)
+}
+
+func (c *Certificate) ValidToGMT() (time.Time, error) {
+	t, ok := c.Get("Valid To [GMT]")
+	if !ok {
+		return time.Time{}, errors.New("ValidToGMT not found.")
+	}
+	return time.Parse(TimeFMT, t)
+}
+
+func (c *Certificate) MarshalJSON() ([]byte, error) {
+	m := make(map[string]string)
+	for key, v := range c.columnMap {
+		m[key] = c.row[v]
+	}
+	return json.Marshal(m)
+}
+
+func NewCertificate(columnMap map[string]int, row []string, lineNum int) *Certificate {
+	p := row[columnMap["PEM Info"]]
+	row[columnMap["PEM Info"]] = p[1 : len(p)-1]
+	return &Certificate{columnMap, row, lineNum}
+}
+
+// NewEntry attempts to build a certdataDiffCCADb.Entry from a provided CCADB certificate.
+func NewEntry(c *Certificate) *certdataDiffCCADB.Entry {
+	var cio string
+	var ciou string
+	var cn string
+	var csn string
+	var pem string
+	var fp string
+	var tb string
+	var tw bool
+	var te bool
+	var ok bool
+	if cio, ok = c.Get(CIO); !ok {
+		log.Printf("Failed to find column in CCADB, %v\n", CIO)
+	}
+	if ciou, ok = c.Get(CIOU); !ok {
+		log.Printf("Failed to find column in CCADB, %v\n", CIOU)
+	}
+	if cn, ok = c.Get(CN); !ok {
+		log.Printf("Failed to find column in CCADB, %v\n", CN)
+	}
+	if csn, ok = c.Get(CSN); !ok {
+		log.Printf("Failed to find column in CCADB, %v\n", CSN)
+	}
+	if pem, ok = c.Get(PEM); !ok {
+		log.Printf("Failed to find column in CCADB, %v\n", PEM)
+	}
+	if fp, ok = c.Get(FP); !ok {
+		log.Printf("Failed to find column in CCADB, %v\n", FP)
+	}
+	if tb, ok = c.Get(TB); !ok {
+		log.Printf("Failed to find column in CCADB, %v\n", TB)
+	}
+	tw, te = strings.Contains(tb, TrustWeb), strings.Contains(tb, TrustEmail)
+	return certdataDiffCCADB.NewEntry(cio, ciou, cn, csn, pem, fp, tw, te,
+		c.lineNum, "ccadb")
+}
+
+func ParseToNormalizedForm(stream io.Reader) ([]*certdataDiffCCADB.Entry, error) {
+	records, err := Parse(stream)
+	if err != nil {
+		return nil, err
+	}
+	entries := make([]*certdataDiffCCADB.Entry, len(records))
+	for i, record := range records {
+		entries[i] = NewEntry(record)
+	}
+	return entries, nil
+}
+
+func Parse(stream io.Reader) ([]*Certificate, error) {
+	records := make([]*Certificate, 0)
+	reader := csv.NewReader(stream)
+	columnMap := make(map[string]int)
+	columns, err := reader.Read()
+	if err != nil {
+		return records, err
+	}
+	// Extract column headers from the first row so we don't have to
+	// hardcode the column numbers
+	for index, attr := range columns {
+		columnMap[attr] = index
+	}
+	lineNum := 1
+	for row, err := reader.Read(); err == nil; row, err = reader.Read() {
+		lineNum += 1
+		records = append(records, NewCertificate(columnMap, row, lineNum))
+		lineNum += strings.Count(strings.Join(row, ""), "\n")
+	}
+	return records, nil
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/certdata/certdata.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/certdata/certdata.go
@@ -1,0 +1,280 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package certdata
+
+import (
+	"bufio"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/mozilla/OneCRL-Tools/certdataDiffCCADB"
+)
+
+// Strings that mark the beginning of blocks of text important for parsing certdata.txt.
+const (
+	URL = "https://hg.mozilla.org/releases/mozilla-beta/raw-file/tip/security/nss/lib/ckfw/builtins/certdata.txt"
+
+	StartCertificate = "CKA_CLASS CK_OBJECT_CLASS CKO_CERTIFICATE" // Declaration of start of Certificate object.
+	StartTrust       = "CKA_CLASS CK_OBJECT_CLASS CKO_NSS_TRUST"   // Declaration of start of a Distrust object.
+
+	WebDistrust = "CKA_TRUST_SERVER_AUTH CK_TRUST CKT_NSS_NOT_TRUSTED"
+	WebTrust    = "CKA_TRUST_SERVER_AUTH CK_TRUST (CKT_NSS_MUST_VERIFY_TRUST|CKT_NSS_TRUSTED_DELEGATOR)"
+
+	EmailDistrust = "CKA_TRUST_EMAIL_PROTECTION CK_TRUST CKT_NSS_NOT_TRUSTED"
+	EmailTrust    = "CKA_TRUST_EMAIL_PROTECTION CK_TRUST (CKT_NSS_MUST_VERIFY_TRUST|CKT_NSS_TRUSTED_DELEGATOR)"
+
+	IssuerPrefix       = "CKA_ISSUER MULTILINE_OCTAL"        // Declaration of start of a CKA_ISSUER block
+	SerialNumberPrefix = "CKA_SERIAL_NUMBER MULTILINE_OCTAL" // Declaration of start of a CKA_SERIAL_NUMBER block.
+	PEMPrefix          = "CKA_VALUE MULTILINE_OCTAL"         // Declaration of start a CKA_VALUE (PEM) block.
+)
+
+var trustWebRegex *regexp.Regexp
+var trustEmailRegex *regexp.Regexp
+
+var countryName asn1.ObjectIdentifier
+var organization asn1.ObjectIdentifier
+var organizationalUnitName asn1.ObjectIdentifier
+var commonName asn1.ObjectIdentifier
+var stateOrProvinceName asn1.ObjectIdentifier
+var localityName asn1.ObjectIdentifier
+var email asn1.ObjectIdentifier
+var serial asn1.ObjectIdentifier
+
+func init() {
+	trustWebRegex = regexp.MustCompile(WebTrust)
+	trustEmailRegex = regexp.MustCompile(EmailTrust)
+
+	countryName = asn1.ObjectIdentifier{2, 5, 4, 6}
+	organization = asn1.ObjectIdentifier{2, 5, 4, 10}
+	organizationalUnitName = asn1.ObjectIdentifier{2, 5, 4, 11}
+	commonName = asn1.ObjectIdentifier{2, 5, 4, 3}
+	stateOrProvinceName = asn1.ObjectIdentifier{2, 5, 4, 8}
+	localityName = asn1.ObjectIdentifier{2, 5, 4, 7}
+	email = asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 1}
+	serial = asn1.ObjectIdentifier{2, 5, 4, 5}
+}
+
+// ParseToNormalizedForm parses the provided certdata.txt into a normalized form
+// that can be use to easily compare against a CCADB report.
+func ParseToNormalizedForm(f io.Reader) ([]*certdataDiffCCADB.Entry, error) {
+	b := bufio.NewReader(f)
+	lineNum := 0
+	r := make([]*certdataDiffCCADB.Entry, 0)
+	for l, err := b.ReadString('\n'); err == nil; l, err = b.ReadString('\n') {
+		lineNum++
+		// A "distrust" object is a bare Trust object that is not preceeded by a Certificate object.
+		if distrust := strings.HasPrefix(l, StartTrust); strings.HasPrefix(l, StartCertificate) || distrust {
+			e, l, err := Extract(b, lineNum, distrust, "certdata")
+			lineNum += l
+			if err != nil {
+				return r, err
+			}
+			r = append(r, e)
+		}
+	}
+	return r, nil
+}
+
+// NewEntry constructs a new certdataDiffCCADB.Entry from the parsed ASN.1 issuer field, the serial number
+// as a hex a string, the PEM as a base64 encoded string, the line number where entry started on,
+// and the absolute path to the file where the entity was extracted from.
+func NewEntry(i pkix.RDNSequence, s string, pem string, hash string, webTrust, emailTrust bool, ln int, fname string) *certdataDiffCCADB.Entry {
+	var on string
+	var oun string
+	var cn string
+	// A pkix.RDNSequence is just a type alias of a slice of OIDs, of which the
+	// exact ordering is not guaranteed. As such, we just have to iterate over
+	// the OIDs to figure out what they are.
+	for _, attr := range i {
+		oid := attr[0].Type
+		switch value := attr[0].Value.(string); true {
+		case oid.Equal(organization):
+			on = value
+		case oid.Equal(organizationalUnitName):
+			oun = value
+		case oid.Equal(commonName):
+			cn = value
+		}
+	}
+	return certdataDiffCCADB.NewEntry(on, oun, cn, s, pem, hash, webTrust, emailTrust, ln, fname)
+}
+
+// Extract extracts the entity from the bufio.Reader, 'b', that starts line number 'start'.
+// 'distrust' is whether or not the entity is a distrust object. This is necessary since
+// distrust objects do not have a PEM to parse out.
+func Extract(b *bufio.Reader, start int, distrust bool, fname string) (*certdataDiffCCADB.Entry, int, error) {
+	issuerFound := false
+	serialFound := false
+	pemFound := false
+	webTrustFound := false
+	emailTrustFound := false
+	lineNum := 0
+	var issuer pkix.RDNSequence
+	var serialNum string
+	var pem string
+	var hash string
+	var webTrust bool
+	var emailTrust bool
+	for l, err := b.ReadString('\n'); err == nil; l, err = b.ReadString('\n') {
+		lineNum++
+		// Putting this break guard here instead of the loop signature makes it easier to count lines.
+		// Distrust objects lack a PEM. Hence (pemFound || distrust).
+		if issuerFound && serialFound && webTrustFound && emailTrustFound && (pemFound || distrust) {
+			break
+		}
+		switch true {
+		case strings.HasPrefix(l, IssuerPrefix):
+			oct, lcount := ExtractMultilineOctal(b)
+			lineNum += lcount
+			issuerFound = true
+			if issuer, err = DecodeIssuer(oct); err != nil {
+				return nil, lineNum, err
+			}
+		case strings.HasPrefix(l, SerialNumberPrefix):
+			oct, lcount := ExtractMultilineOctal(b)
+			lineNum += lcount
+			serialFound = true
+			if serialNum, err = DecodeSerialNumber(oct); err != nil {
+				return nil, lineNum, err
+			}
+		case strings.HasPrefix(l, SerialNumberPrefix):
+			oct, lcount := ExtractMultilineOctal(b)
+			lineNum += lcount
+			serialFound = true
+			if serialNum, err = DecodeSerialNumber(oct); err != nil {
+				return nil, lineNum, err
+			}
+		case !distrust && strings.HasPrefix(l, PEMPrefix):
+			oct, lcount := ExtractMultilineOctal(b)
+			lineNum += lcount
+			pemFound = true
+			if pem, hash, err = DecodeDER(oct); err != nil {
+				return nil, lineNum, err
+			}
+		case trustWebRegex.MatchString(l):
+			webTrust = true
+			webTrustFound = true
+		case strings.HasPrefix(l, WebDistrust):
+			webTrust = false
+			webTrustFound = true
+		case trustEmailRegex.MatchString(l):
+			emailTrust = true
+			emailTrustFound = true
+		case strings.HasPrefix(l, EmailDistrust):
+			emailTrust = false
+			emailTrustFound = true
+		}
+	}
+	if !(issuerFound && serialFound && webTrustFound && emailTrustFound && (pemFound || distrust)) {
+		return nil, lineNum, errors.New("unexpected EOF")
+	}
+	e := NewEntry(issuer, serialNum, pem, hash, webTrust, emailTrust, start, fname)
+	return e, lineNum, nil
+}
+
+// DecodeIssuer parses the CKA_ISSUER MULTILINE_OCTAL field of certdata.txt.
+func DecodeIssuer(octal string) (pkix.RDNSequence, error) {
+	b, err := otobs(octal)
+	if err != nil {
+		return nil, err
+	}
+	var i pkix.RDNSequence
+	if rest, err := asn1.Unmarshal(b, &i); err != nil {
+		return nil, err
+	} else if len(rest) != 0 {
+		return nil, errors.New("issuer field had trailing data")
+	}
+	return i, nil
+}
+
+// DecodeSerialNumber takes a DER encoded octal string and returns
+// the base64 encoded serial number.
+func DecodeSerialNumber(octal string) (string, error) {
+	b, err := otobs(octal)
+	if err != nil {
+		return "", err
+	}
+	s := new(big.Int)
+	if rest, err := asn1.Unmarshal(b, &s); err != nil {
+		return "", err
+	} else if len(rest) != 0 {
+		return "", errors.New("serial number field had trailing data")
+	}
+	// %x fmts to hex
+	return fmt.Sprintf("%x", s), nil
+}
+
+// DecodeDER takes a DER encoded octal string and returns the base64
+// encoded certificate as well as its SHA-256 hash. No newlines, BEGIN,
+// or END fields are present on the decoded string.
+func DecodeDER(octal string) (string, string, error) {
+	b, err := otobs(octal)
+	if err != nil {
+		return "", "", err
+	}
+	c, err := x509.ParseCertificate(b)
+	if err != nil {
+		return "", "", err
+	}
+	h := sha256.New()
+	h.Write(b)
+	f := FmtFingerprint(fmt.Sprintf("%x", h.Sum(nil)))
+	pem := base64.StdEncoding.EncodeToString(c.Raw)
+	return pem, f, nil
+}
+
+// FmtFingerprint formats a SHA 256 hash with colons.
+func FmtFingerprint(h string) string {
+	h = strings.ToUpper(h)
+	f := make([]byte, 95) // 64 characters + 31 ':'
+	copy(f[0:2], h[0:2])
+	ci := 2
+	for i := 2; i < len(h); i += 2 {
+		f[ci] = ':'
+		copy(f[ci+1:ci+3], h[i:i+2])
+		ci += 3
+	}
+	return string(f)
+}
+
+// ExtractMultilineOctal consumes the provided bufio.Reader and returns a string
+// of '\' delimited octal values and then number of lines consumed to extract
+// the octal value.
+func ExtractMultilineOctal(b *bufio.Reader) (string, int) {
+	var oct []string
+	lines := 0
+	for l, err := b.ReadString('\n'); err == nil; l, err = b.ReadString('\n') {
+		lines++
+		// Putting this break guard here instead of the loop signature makes it easier to count lines.
+		if strings.HasPrefix(l, "END") {
+			break
+		}
+		oct = append(oct, strings.Trim(l, "\n"))
+	}
+	return strings.Join(oct, ""), lines
+}
+
+// otobs converts a string containing `\` delimited octal values to a byte slice.
+// An error can occur if a supposed octal value fails to convert to an integer.
+func otobs(oct string) (result []byte, err error) {
+	var b int64
+	for _, o := range strings.Split(oct, `\`)[1:] {
+		if b, err = strconv.ParseInt(o, 8, 0); err != nil {
+			return
+		}
+		result = append(result, byte(b))
+	}
+	return
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/certdataDiffCCADB/entry.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/certdataDiffCCADB/entry.go
@@ -1,0 +1,87 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package certdataDiffCCADB
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Certificate normalization constants.
+const (
+	BEGIN = "-----BEGIN CERTIFICATE-----\n"
+	END   = "-----END CERTIFICATE-----"
+	WIDTH = 64 // Columns per line https://tools.ietf.org/html/rfc1421
+)
+
+var stripper *regexp.Regexp
+
+func init() {
+	stripper = regexp.MustCompile("('|'|\n|-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----)")
+}
+
+// Entry is a normalized form of a Certificate Authority found
+// in either certdata.txt or from a CCADB report CSV.
+type Entry struct {
+	OrganizationName       string `json:"organizationName"`
+	OrganizationalUnitName string `json:"organizationalUnitName"`
+	CommonName             string `json:"commonName"`
+	SerialNumber           string `json:"serialNumber"`
+	PEM                    string `json:"-"`
+	Fingerprint            string `json:"sha256"`
+	TrustWeb               bool   `json:"trustWeb"`
+	TrustEmail             bool   `json:"trustEmail"`
+	LineNumber             int    `json:"lineNumber"`
+	Origin                 string `json:"origin"`
+}
+
+// UniqueID returns the issuer distinguished name and the serial (noralized with no leading zeroes)
+// contatenated together.
+func (e *Entry) UniqueID() string {
+	return fmt.Sprintf("%v%v", e.DistinguishedName(), e.NormalizedSerial())
+}
+
+// DistinguishedName builds a hierarchical string of Organization, Orgizational Unit, and Common Name.
+func (e *Entry) DistinguishedName() string {
+	return fmt.Sprintf("O=%v/OU=%v/CN=%v", e.OrganizationName, e.OrganizationalUnitName, e.CommonName)
+}
+
+// NormalizedSerial returns the serial number with any leading zeroes stripped off.
+func (e *Entry) NormalizedSerial() string {
+	return strings.TrimLeft(e.SerialNumber, "0")
+}
+
+// NewEntry constructs a new Entry with a normalized PEM.
+func NewEntry(org, orgUnit, commonName, serial, pem, fingerprint string, trustWeb, trustEmail bool, line int, origin string) *Entry {
+	return &Entry{org, orgUnit, commonName, serial, normalizePEM(pem), fingerprint, trustWeb, trustEmail, line, origin}
+}
+
+// normalizePEM ignores any formatting or string artifacts that the PEM may have had
+// and applies https://tools.ietf.org/html/rfc1421
+//
+// This stemmed from noticing that CCADB reports were fully formed while certdata
+// PEMS had no formatting nor BEGIN/END fields. This is simply avoiding any surprises
+// in individual formatting choices by forcing both to strip all formatting and conform
+// to the one, chosen, way.
+func normalizePEM(pem string) string {
+	if len(pem) == 0 {
+		return ""
+	}
+	pem = stripper.ReplaceAllString(pem, "")
+	p := []byte(pem)
+	fmted := []byte(BEGIN)
+	width := WIDTH
+	for len(p) > 0 {
+		if len(p) < WIDTH {
+			width = len(p)
+		}
+		fmted = append(fmted, p[:width]...)
+		fmted = append(fmted, '\n')
+		p = p[width:]
+	}
+	fmted = append(fmted, END...)
+	return string(fmted)
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/certdataDiffCCADB/pair.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/mozilla/OneCRL-Tools/certdataDiffCCADB/pair.go
@@ -1,0 +1,96 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package certdataDiffCCADB
+
+// Pair holds a normalized certdata.txt entry, it's sister CCADB,
+// as well a slice of what fields between the two are differnt.
+type Pair struct {
+	Certdata *Entry
+	CCADB    *Entry
+	Diffs    []string
+}
+
+// MapPairs map all of the entries in certdata.txt to entries in the CCADB
+// report. Entries are matched together if they:
+//
+// 1. Have the same serial number (normalized for leading zeroes)
+// 	or
+// 2. They have the exact same PEM.
+//	or
+// 3. They have the exact same Common Name.
+//
+// Any entries for which a mapping could not be made are returned
+// in the 'rest' slice.
+func MapPairs(cd, ccadb []*Entry) (pairs []Pair, unmatchedT []*Entry, unmatchedUT []*Entry) {
+	idMap := make(map[string]*Entry) // DN || serial
+	ftocd := make(map[string]*Entry) // fingerprint
+	for _, e := range cd {
+		idMap[e.UniqueID()] = e
+		ftocd[e.Fingerprint] = e
+	}
+	var pair Pair
+	var match *Entry
+	var ok bool
+	for _, e := range ccadb {
+		id := e.UniqueID()
+		if match, ok = idMap[id]; ok {
+			pair = NewPair(match, e)
+		} else if match, ok = ftocd[e.Fingerprint]; ok {
+			pair = NewPair(match, e)
+		} else {
+			if !(e.TrustWeb || e.TrustEmail) {
+				unmatchedUT = append(unmatchedUT, e)
+			} else {
+				unmatchedT = append(unmatchedT, e)
+			}
+			continue
+		}
+		pairs = append(pairs, pair)
+		// Avoid matching duplicates
+		delete(idMap, match.UniqueID())
+		delete(ftocd, match.Fingerprint)
+	}
+	for _, e := range idMap {
+		if !(e.TrustWeb || e.TrustEmail) {
+			unmatchedUT = append(unmatchedUT, e)
+		} else {
+			unmatchedT = append(unmatchedT, e)
+		}
+	}
+	return
+}
+
+// NewPair discovers the difference between a matched certdata.txt entry
+// and a CCADB report entry and constructs a new Pair.
+func NewPair(cd, ccadb *Entry) (p Pair) {
+	p.Certdata = cd
+	p.CCADB = ccadb
+	p.Diffs = make([]string, 0)
+	if cd.OrganizationName != ccadb.OrganizationName {
+		p.Diffs = append(p.Diffs, "OrganizationName")
+	}
+	if cd.OrganizationalUnitName != ccadb.OrganizationalUnitName {
+		p.Diffs = append(p.Diffs, "OrganizationalUnitName")
+	}
+	if cd.CommonName != ccadb.CommonName {
+		p.Diffs = append(p.Diffs, "CommonName")
+	}
+	if cd.SerialNumber != ccadb.SerialNumber {
+		p.Diffs = append(p.Diffs, "SerialNumber")
+	}
+	if cd.PEM != ccadb.PEM {
+		p.Diffs = append(p.Diffs, "PEM")
+	}
+	if cd.Fingerprint != ccadb.Fingerprint {
+		p.Diffs = append(p.Diffs, "Fingerprint")
+	}
+	if cd.TrustWeb != ccadb.TrustWeb {
+		p.Diffs = append(p.Diffs, "TrustWeb")
+	}
+	if cd.TrustEmail != ccadb.TrustEmail {
+		p.Diffs = append(p.Diffs, "TrustEmail")
+	}
+	return
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/.gitignore
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/.gitignore
@@ -1,0 +1,5 @@
+.DS_Store
+*.swp
+*.swo
+*.test
+*.out

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/.travis.yml
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/.travis.yml
@@ -1,0 +1,22 @@
+sudo: false
+
+language: go
+
+go:
+    - 1.7
+    - 1.8
+    - 1.9
+    # 1.x builds the latest in that series. Also try to add other versions here
+    # as they come up so that we're pretty sure that we're maintaining
+    # backwards compatibility.
+    - 1.x
+
+notifications:
+  email: false
+
+services:
+  - redis-server
+
+install: make get-deps
+
+script: make

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/LICENSE
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/LICENSE
@@ -1,0 +1,12 @@
+Copyright (c) 2014, Martin Angers and Contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+* Neither the name of the author nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/Makefile
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/Makefile
@@ -1,0 +1,29 @@
+
+
+.PHONY: test test-cover bench lint get-deps .go-test .go-test-cover
+
+test: .go-test bench lint
+
+test-cover: .go-test-cover bench lint
+
+bench:
+	go test -race -bench=. -cpu=1,2,4
+
+lint:
+	gofmt -l .
+	go vet ./...
+	which golint # Fail if golint doesn't exist
+	-golint . # Don't fail on golint warnings themselves
+	-golint store # Don't fail on golint warnings themselves
+
+get-deps:
+	go get github.com/garyburd/redigo/redis
+	go get github.com/hashicorp/golang-lru
+	go get github.com/golang/lint/golint
+
+.go-test:
+	go test ./...
+
+.go-test-cover:
+	go test -coverprofile=throttled.coverage.out .
+	go test -coverprofile=store.coverage.out ./store

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/README.md
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/README.md
@@ -1,0 +1,60 @@
+# Throttled [![build status](https://secure.travis-ci.org/throttled/throttled.svg)](https://travis-ci.org/throttled/throttled) [![GoDoc](https://godoc.org/github.com/throttled/throttled?status.svg)](https://godoc.org/github.com/throttled/throttled)
+
+Package throttled implements rate limiting using the [generic cell rate
+algorithm][gcra] to limit access to resources such as HTTP endpoints.
+
+The 2.0.0 release made some major changes to the throttled API. If
+this change broke your code in problematic ways or you wish a feature
+of the old API had been retained, please open an issue.  We don't
+guarantee any particular changes but would like to hear more about
+what our users need. Thanks!
+
+## Installation
+
+```sh
+go get -u github.com/throttled/throttled
+```
+
+## Documentation
+
+API documentation is available on [godoc.org][doc]. The following
+example demonstrates the usage of HTTPLimiter for rate-limiting access
+to an http.Handler to 20 requests per path per minute with bursts of
+up to 5 additional requests:
+
+```go
+store, err := memstore.New(65536)
+if err != nil {
+	log.Fatal(err)
+}
+
+quota := throttled.RateQuota{throttled.PerMin(20), 5}
+rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+if err != nil {
+	log.Fatal(err)
+}
+
+httpRateLimiter := throttled.HTTPRateLimiter{
+	RateLimiter: rateLimiter,
+	VaryBy:      &throttled.VaryBy{Path: true},
+}
+
+http.ListenAndServe(":8080", httpRateLimiter.RateLimit(myHandler))
+```
+
+## Related Projects
+
+See [throttled/gcra][throttled-gcra] for a list of other projects related to
+rate limiting and GCRA.
+
+## License
+
+The [BSD 3-clause license][bsd]. Copyright (c) 2014 Martin Angers and contributors.
+
+[blog]: http://0value.com/throttled--guardian-of-the-web-server
+[bsd]: https://opensource.org/licenses/BSD-3-Clause
+[doc]: https://godoc.org/github.com/throttled/throttled
+[gcra]: https://en.wikipedia.org/wiki/Generic_cell_rate_algorithm
+[puerkitobio]: https://github.com/puerkitobio/
+[pr]: https://github.com/throttled/throttled/compare
+[throttled-gcra]: https://github.com/throttled/gcra

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/deprecated.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/deprecated.go
@@ -1,0 +1,73 @@
+package throttled
+
+import (
+	"net/http"
+	"time"
+)
+
+// DEPRECATED. Quota returns the number of requests allowed and the custom time window.
+func (q Rate) Quota() (int, time.Duration) {
+	return q.count, q.period * time.Duration(q.count)
+}
+
+// DEPRECATED. Q represents a custom quota.
+type Q struct {
+	Requests int
+	Window   time.Duration
+}
+
+// DEPRECATED. Quota returns the number of requests allowed and the custom time window.
+func (q Q) Quota() (int, time.Duration) {
+	return q.Requests, q.Window
+}
+
+// DEPRECATED. The Quota interface defines the method to implement to describe
+// a time-window quota, as required by the RateLimit throttler.
+type Quota interface {
+	// Quota returns a number of requests allowed, and a duration.
+	Quota() (int, time.Duration)
+}
+
+// DEPRECATED. Throttler is a backwards-compatible alias for HTTPLimiter.
+type Throttler struct {
+	HTTPRateLimiter
+}
+
+// DEPRECATED. Throttle is an alias for HTTPLimiter#Limit
+func (t *Throttler) Throttle(h http.Handler) http.Handler {
+	return t.RateLimit(h)
+}
+
+// DEPRECATED. RateLimit creates a Throttler that conforms to the given
+// rate limits
+func RateLimit(q Quota, vary *VaryBy, store GCRAStore) *Throttler {
+	count, period := q.Quota()
+
+	if count < 1 {
+		count = 1
+	}
+	if period <= 0 {
+		period = time.Second
+	}
+
+	rate := Rate{period: period / time.Duration(count)}
+	limiter, err := NewGCRARateLimiter(store, RateQuota{rate, count - 1})
+
+	// This panic in unavoidable because the original interface does
+	// not support returning an error.
+	if err != nil {
+		panic(err)
+	}
+
+	return &Throttler{
+		HTTPRateLimiter{
+			RateLimiter: limiter,
+			VaryBy:      vary,
+		},
+	}
+}
+
+// DEPRECATED. Store is an alias for GCRAStore
+type Store interface {
+	GCRAStore
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/doc.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/doc.go
@@ -1,0 +1,3 @@
+// Package throttled implements rate limiting access to resources such
+// as HTTP endpoints.
+package throttled

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/http.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/http.go
@@ -1,0 +1,110 @@
+package throttled
+
+import (
+	"errors"
+	"math"
+	"net/http"
+	"strconv"
+)
+
+var (
+	// DefaultDeniedHandler is the default DeniedHandler for an
+	// HTTPRateLimiter. It returns a 429 status code with a generic
+	// message.
+	DefaultDeniedHandler = http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "limit exceeded", 429)
+	}))
+
+	// DefaultError is the default Error function for an HTTPRateLimiter.
+	// It returns a 500 status code with a generic message.
+	DefaultError = func(w http.ResponseWriter, r *http.Request, err error) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}
+)
+
+// HTTPRateLimiter faciliates using a Limiter to limit HTTP requests.
+type HTTPRateLimiter struct {
+	// DeniedHandler is called if the request is disallowed. If it is
+	// nil, the DefaultDeniedHandler variable is used.
+	DeniedHandler http.Handler
+
+	// Error is called if the RateLimiter returns an error. If it is
+	// nil, the DefaultErrorFunc is used.
+	Error func(w http.ResponseWriter, r *http.Request, err error)
+
+	// Limiter is call for each request to determine whether the
+	// request is permitted and update internal state. It must be set.
+	RateLimiter RateLimiter
+
+	// VaryBy is called for each request to generate a key for the
+	// limiter. If it is nil, all requests use an empty string key.
+	VaryBy interface {
+		Key(*http.Request) string
+	}
+}
+
+// RateLimit wraps an http.Handler to limit incoming requests.
+// Requests that are not limited will be passed to the handler
+// unchanged.  Limited requests will be passed to the DeniedHandler.
+// X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset and
+// Retry-After headers will be written to the response based on the
+// values in the RateLimitResult.
+func (t *HTTPRateLimiter) RateLimit(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if t.RateLimiter == nil {
+			t.error(w, r, errors.New("You must set a RateLimiter on HTTPRateLimiter"))
+		}
+
+		var k string
+		if t.VaryBy != nil {
+			k = t.VaryBy.Key(r)
+		}
+
+		limited, context, err := t.RateLimiter.RateLimit(k, 1)
+
+		if err != nil {
+			t.error(w, r, err)
+			return
+		}
+
+		setRateLimitHeaders(w, context)
+
+		if !limited {
+			h.ServeHTTP(w, r)
+		} else {
+			dh := t.DeniedHandler
+			if dh == nil {
+				dh = DefaultDeniedHandler
+			}
+			dh.ServeHTTP(w, r)
+		}
+	})
+}
+
+func (t *HTTPRateLimiter) error(w http.ResponseWriter, r *http.Request, err error) {
+	e := t.Error
+	if e == nil {
+		e = DefaultError
+	}
+	e(w, r, err)
+}
+
+func setRateLimitHeaders(w http.ResponseWriter, context RateLimitResult) {
+	if v := context.Limit; v >= 0 {
+		w.Header().Add("X-RateLimit-Limit", strconv.Itoa(v))
+	}
+
+	if v := context.Remaining; v >= 0 {
+		w.Header().Add("X-RateLimit-Remaining", strconv.Itoa(v))
+	}
+
+	if v := context.ResetAfter; v >= 0 {
+		vi := int(math.Ceil(v.Seconds()))
+		w.Header().Add("X-RateLimit-Reset", strconv.Itoa(vi))
+	}
+
+	if v := context.RetryAfter; v >= 0 {
+		vi := int(math.Ceil(v.Seconds()))
+		w.Header().Add("Retry-After", strconv.Itoa(vi))
+	}
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/rate.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/rate.go
@@ -1,0 +1,242 @@
+package throttled
+
+import (
+	"fmt"
+	"time"
+)
+
+const (
+	// Maximum number of times to retry SetIfNotExists/CompareAndSwap operations
+	// before returning an error.
+	maxCASAttempts = 10
+)
+
+// A RateLimiter manages limiting the rate of actions by key.
+type RateLimiter interface {
+	// RateLimit checks whether a particular key has exceeded a rate
+	// limit. It also returns a RateLimitResult to provide additional
+	// information about the state of the RateLimiter.
+	//
+	// If the rate limit has not been exceeded, the underlying storage
+	// is updated by the supplied quantity. For example, a quantity of
+	// 1 might be used to rate limit a single request while a greater
+	// quantity could rate limit based on the size of a file upload in
+	// megabytes. If quantity is 0, no update is performed allowing
+	// you to "peek" at the state of the RateLimiter for a given key.
+	RateLimit(key string, quantity int) (bool, RateLimitResult, error)
+}
+
+// RateLimitResult represents the state of the RateLimiter for a
+// given key at the time of the query. This state can be used, for
+// example, to communicate information to the client via HTTP
+// headers. Negative values indicate that the attribute is not
+// relevant to the implementation or state.
+type RateLimitResult struct {
+	// Limit is the maximum number of requests that could be permitted
+	// instantaneously for this key starting from an empty state. For
+	// example, if a rate limiter allows 10 requests per second per
+	// key, Limit would always be 10.
+	Limit int
+
+	// Remaining is the maximum number of requests that could be
+	// permitted instantaneously for this key given the current
+	// state. For example, if a rate limiter allows 10 requests per
+	// second and has already received 6 requests for this key this
+	// second, Remaining would be 4.
+	Remaining int
+
+	// ResetAfter is the time until the RateLimiter returns to its
+	// initial state for a given key. For example, if a rate limiter
+	// manages requests per second and received one request 200ms ago,
+	// Reset would return 800ms. You can also think of this as the time
+	// until Limit and Remaining will be equal.
+	ResetAfter time.Duration
+
+	// RetryAfter is the time until the next request will be permitted.
+	// It should be -1 unless the rate limit has been exceeded.
+	RetryAfter time.Duration
+}
+
+type limitResult struct {
+	limited bool
+}
+
+func (r *limitResult) Limited() bool { return r.limited }
+
+type rateLimitResult struct {
+	limitResult
+
+	limit, remaining  int
+	reset, retryAfter time.Duration
+}
+
+func (r *rateLimitResult) Limit() int                { return r.limit }
+func (r *rateLimitResult) Remaining() int            { return r.remaining }
+func (r *rateLimitResult) Reset() time.Duration      { return r.reset }
+func (r *rateLimitResult) RetryAfter() time.Duration { return r.retryAfter }
+
+// Rate describes a frequency of an activity such as the number of requests
+// allowed per minute.
+type Rate struct {
+	period time.Duration // Time between equally spaced requests at the rate
+	count  int           // Used internally for deprecated `RateLimit` interface only
+}
+
+// RateQuota describes the number of requests allowed per time period.
+// MaxRate specified the maximum sustained rate of requests and must
+// be greater than zero. MaxBurst defines the number of requests that
+// will be allowed to exceed the rate in a single burst and must be
+// greater than or equal to zero.
+//
+// Rate{PerSec(1), 0} would mean that after each request, no more
+// requests will be permitted for that client for one second.
+// Rate{PerSec(2), 0} permits one request per 0.5 seconds rather than
+// two requests in one second. In practice, you probably want to set
+// MaxBurst >0 to provide some flexibility to clients that only need
+// to make a handful of requests. In fact a MaxBurst of zero will
+// *never* permit a request with a quantity greater than one because
+// it will immediately exceed the limit.
+type RateQuota struct {
+	MaxRate  Rate
+	MaxBurst int
+}
+
+// PerSec represents a number of requests per second.
+func PerSec(n int) Rate { return Rate{time.Second / time.Duration(n), n} }
+
+// PerMin represents a number of requests per minute.
+func PerMin(n int) Rate { return Rate{time.Minute / time.Duration(n), n} }
+
+// PerHour represents a number of requests per hour.
+func PerHour(n int) Rate { return Rate{time.Hour / time.Duration(n), n} }
+
+// PerDay represents a number of requests per day.
+func PerDay(n int) Rate { return Rate{24 * time.Hour / time.Duration(n), n} }
+
+// GCRARateLimiter is a RateLimiter that users the generic cell-rate
+// algorithm. The algorithm has been slightly modified from its usual
+// form to support limiting with an additional quantity parameter, such
+// as for limiting the number of bytes uploaded.
+type GCRARateLimiter struct {
+	limit int
+
+	// Think of the DVT as our flexibility:
+	// How far can you deviate from the nominal equally spaced schedule?
+	// If you like leaky buckets, think about it as the size of your bucket.
+	delayVariationTolerance time.Duration
+
+	// Think of the emission interval as the time between events
+	// in the nominal equally spaced schedule. If you like leaky buckets,
+	// think of it as how frequently the bucket leaks one unit.
+	emissionInterval time.Duration
+
+	store GCRAStore
+}
+
+// NewGCRARateLimiter creates a GCRARateLimiter. quota.Count defines
+// the maximum number of requests permitted in an instantaneous burst
+// and quota.Count / quota.Period defines the maximum sustained
+// rate. For example, PerMin(60) permits 60 requests instantly per key
+// followed by one request per second indefinitely whereas PerSec(1)
+// only permits one request per second with no tolerance for bursts.
+func NewGCRARateLimiter(st GCRAStore, quota RateQuota) (*GCRARateLimiter, error) {
+	if quota.MaxBurst < 0 {
+		return nil, fmt.Errorf("Invalid RateQuota %#v. MaxBurst must be greater than zero.", quota)
+	}
+	if quota.MaxRate.period <= 0 {
+		return nil, fmt.Errorf("Invalid RateQuota %#v. MaxRate must be greater than zero.", quota)
+	}
+
+	return &GCRARateLimiter{
+		delayVariationTolerance: quota.MaxRate.period * (time.Duration(quota.MaxBurst) + 1),
+		emissionInterval:        quota.MaxRate.period,
+		limit:                   quota.MaxBurst + 1,
+		store:                   st,
+	}, nil
+}
+
+// RateLimit checks whether a particular key has exceeded a rate
+// limit. It also returns a RateLimitResult to provide additional
+// information about the state of the RateLimiter.
+//
+// If the rate limit has not been exceeded, the underlying storage is
+// updated by the supplied quantity. For example, a quantity of 1
+// might be used to rate limit a single request while a greater
+// quantity could rate limit based on the size of a file upload in
+// megabytes. If quantity is 0, no update is performed allowing you
+// to "peek" at the state of the RateLimiter for a given key.
+func (g *GCRARateLimiter) RateLimit(key string, quantity int) (bool, RateLimitResult, error) {
+	var tat, newTat, now time.Time
+	var ttl time.Duration
+	rlc := RateLimitResult{Limit: g.limit, RetryAfter: -1}
+	limited := false
+
+	i := 0
+	for {
+		var err error
+		var tatVal int64
+		var updated bool
+
+		// tat refers to the theoretical arrival time that would be expected
+		// from equally spaced requests at exactly the rate limit.
+		tatVal, now, err = g.store.GetWithTime(key)
+		if err != nil {
+			return false, rlc, err
+		}
+
+		if tatVal == -1 {
+			tat = now
+		} else {
+			tat = time.Unix(0, tatVal)
+		}
+
+		increment := time.Duration(quantity) * g.emissionInterval
+		if now.After(tat) {
+			newTat = now.Add(increment)
+		} else {
+			newTat = tat.Add(increment)
+		}
+
+		// Block the request if the next permitted time is in the future
+		allowAt := newTat.Add(-(g.delayVariationTolerance))
+		if diff := now.Sub(allowAt); diff < 0 {
+			if increment <= g.delayVariationTolerance {
+				rlc.RetryAfter = -diff
+			}
+			ttl = tat.Sub(now)
+			limited = true
+			break
+		}
+
+		ttl = newTat.Sub(now)
+
+		if tatVal == -1 {
+			updated, err = g.store.SetIfNotExistsWithTTL(key, newTat.UnixNano(), ttl)
+		} else {
+			updated, err = g.store.CompareAndSwapWithTTL(key, tatVal, newTat.UnixNano(), ttl)
+		}
+
+		if err != nil {
+			return false, rlc, err
+		}
+		if updated {
+			break
+		}
+
+		i++
+		if i > maxCASAttempts {
+			return false, rlc, fmt.Errorf(
+				"Failed to store updated rate limit data for key %s after %d attempts",
+				key, i,
+			)
+		}
+	}
+
+	next := g.delayVariationTolerance - ttl
+	if next > -g.emissionInterval {
+		rlc.Remaining = int(next / g.emissionInterval)
+	}
+	rlc.ResetAfter = ttl
+
+	return limited, rlc, nil
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/store.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/store.go
@@ -1,0 +1,34 @@
+package throttled
+
+import (
+	"time"
+)
+
+// GCRAStore is the interface to implement to store state for a GCRA
+// rate limiter
+type GCRAStore interface {
+	// GetWithTime returns the value of the key if it is in the store
+	// or -1 if it does not exist. It also returns the current time at
+	// the Store. The time must be representable as a positive int64
+	// of nanoseconds since the epoch.
+	//
+	// GCRA assumes that all instances sharing the same Store also
+	// share the same clock. Using separate clocks will work if the
+	// skew is small but not recommended in practice unless you're
+	// lucky enough to be hooked up to GPS or atomic clocks.
+	GetWithTime(key string) (int64, time.Time, error)
+
+	// SetIfNotExistsWithTTL sets the value of key only if it is not
+	// already set in the store it returns whether a new value was
+	// set. If the store supports expiring keys and a new value was
+	// set, the key will expire after the provided ttl.
+	SetIfNotExistsWithTTL(key string, value int64, ttl time.Duration) (bool, error)
+
+	// CompareAndSwapWithTTL atomically compares the value at key to
+	// the old value. If it matches, it sets it to the new value and
+	// returns true. Otherwise, it returns false. If the key does not
+	// exist in the store, it returns false with no error. If the
+	// store supports expiring keys and the swap succeeded, the key
+	// will expire after the provided ttl.
+	CompareAndSwapWithTTL(key string, old, new int64, ttl time.Duration) (bool, error)
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/store/memstore/memstore.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/store/memstore/memstore.go
@@ -1,0 +1,127 @@
+// Package memstore offers an in-memory store implementation for throttled.
+package memstore
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/hashicorp/golang-lru"
+)
+
+// MemStore is an in-memory store implementation for throttled. It
+// supports evicting the least recently used keys to control memory
+// usage. It is stored in memory in the current process and thus
+// doesn't share state with other rate limiters.
+type MemStore struct {
+	sync.RWMutex
+	keys *lru.Cache
+	m    map[string]*int64
+}
+
+// New initializes a Store. If maxKeys > 0, the number of different
+// keys is restricted to the specified amount. In this case, it uses
+// an LRU algorithm to evict older keys to make room for newer
+// ones. If maxKeys <= 0, there is no limit on the number of keys,
+// which may use an unbounded amount of memory.
+func New(maxKeys int) (*MemStore, error) {
+	var m *MemStore
+
+	if maxKeys > 0 {
+		keys, err := lru.New(maxKeys)
+		if err != nil {
+			return nil, err
+		}
+
+		m = &MemStore{
+			keys: keys,
+		}
+	} else {
+		m = &MemStore{
+			m: make(map[string]*int64),
+		}
+	}
+	return m, nil
+}
+
+// GetWithTime returns the value of the key if it is in the store or
+// -1 if it does not exist. It also returns the current local time on
+// the machine.
+func (ms *MemStore) GetWithTime(key string) (int64, time.Time, error) {
+	now := time.Now()
+	valP, ok := ms.get(key, false)
+
+	if !ok {
+		return -1, now, nil
+	}
+
+	return atomic.LoadInt64(valP), now, nil
+}
+
+// SetIfNotExistsWithTTL sets the value of key only if it is not
+// already set in the store it returns whether a new value was set. It
+// ignores the ttl.
+func (ms *MemStore) SetIfNotExistsWithTTL(key string, value int64, _ time.Duration) (bool, error) {
+	_, ok := ms.get(key, false)
+
+	if ok {
+		return false, nil
+	}
+
+	ms.Lock()
+	defer ms.Unlock()
+
+	_, ok = ms.get(key, true)
+
+	if ok {
+		return false, nil
+	}
+
+	// Store a pointer to a new instance so that the caller
+	// can't mutate the value after setting
+	v := value
+
+	if ms.keys != nil {
+		ms.keys.Add(key, &v)
+	} else {
+		ms.m[key] = &v
+	}
+
+	return true, nil
+}
+
+// CompareAndSwapWithTTL atomically compares the value at key to the
+// old value. If it matches, it sets it to the new value and returns
+// true. Otherwise, it returns false. If the key does not exist in the
+// store, it returns false with no error. It ignores the ttl.
+func (ms *MemStore) CompareAndSwapWithTTL(key string, old, new int64, _ time.Duration) (bool, error) {
+	valP, ok := ms.get(key, false)
+
+	if !ok {
+		return false, nil
+	}
+
+	return atomic.CompareAndSwapInt64(valP, old, new), nil
+}
+
+func (ms *MemStore) get(key string, locked bool) (*int64, bool) {
+	var valP *int64
+	var ok bool
+
+	if ms.keys != nil {
+		var valI interface{}
+
+		valI, ok = ms.keys.Get(key)
+		if ok {
+			valP = valI.(*int64)
+		}
+	} else {
+		if !locked {
+			ms.RLock()
+			defer ms.RUnlock()
+		}
+		valP, ok = ms.m[key]
+	}
+
+	return valP, ok
+}

--- a/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/varyby.go
+++ b/cmd/certdataDiffCCADB/vendor/github.com/throttled/throttled/varyby.go
@@ -1,0 +1,78 @@
+package throttled
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+)
+
+// VaryBy defines the criteria to use to group requests.
+type VaryBy struct {
+	// Vary by the RemoteAddr as specified by the net/http.Request field.
+	RemoteAddr bool
+
+	// Vary by the HTTP Method as specified by the net/http.Request field.
+	Method bool
+
+	// Vary by the URL's Path as specified by the Path field of the net/http.Request
+	// URL field.
+	Path bool
+
+	// Vary by this list of header names, read from the net/http.Request Header field.
+	Headers []string
+
+	// Vary by this list of parameters, read from the net/http.Request FormValue method.
+	Params []string
+
+	// Vary by this list of cookie names, read from the net/http.Request Cookie method.
+	Cookies []string
+
+	// Use this separator string to concatenate the various criteria of the VaryBy struct.
+	// Defaults to a newline character if empty (\n).
+	Separator string
+
+	// DEPRECATED. Custom specifies the custom-generated key to use for this request.
+	// If not nil, the value returned by this function is used instead of any
+	// VaryBy criteria.
+	Custom func(r *http.Request) string
+}
+
+// Key returns the key for this request based on the criteria defined by the VaryBy struct.
+func (vb *VaryBy) Key(r *http.Request) string {
+	var buf bytes.Buffer
+
+	if vb == nil {
+		return "" // Special case for no vary-by option
+	}
+	if vb.Custom != nil {
+		// A custom key generator is specified
+		return vb.Custom(r)
+	}
+	sep := vb.Separator
+	if sep == "" {
+		sep = "\n" // Separator defaults to newline
+	}
+	if vb.RemoteAddr {
+		buf.WriteString(strings.ToLower(r.RemoteAddr) + sep)
+	}
+	if vb.Method {
+		buf.WriteString(strings.ToLower(r.Method) + sep)
+	}
+	for _, h := range vb.Headers {
+		buf.WriteString(strings.ToLower(r.Header.Get(h)) + sep)
+	}
+	if vb.Path {
+		buf.WriteString(r.URL.Path + sep)
+	}
+	for _, p := range vb.Params {
+		buf.WriteString(r.FormValue(p) + sep)
+	}
+	for _, c := range vb.Cookies {
+		ck, err := r.Cookie(c)
+		if err == nil {
+			buf.WriteString(ck.Value)
+		}
+		buf.WriteString(sep) // Write the separator anyway, whether or not the cookie exists
+	}
+	return buf.String()
+}

--- a/deploy_to_heroku.sh
+++ b/deploy_to_heroku.sh
@@ -1,0 +1,1 @@
+cmd/certdataDiffCCADB/deploy_to_heroku.sh


### PR DESCRIPTION
As requested, I added a server mode that serves up _only_ a list of simplified certdata objects. Poonam would rather use the Observatory to parse out information from the PEM than support this code's logic for extracting the bulk of the certdata info (it is still extracting everything, it's just throwing most of it away).