### PR TITLE
Fix travis for Go 1.11

### DIFF
--- a/bugs/bugs.go
+++ b/bugs/bugs.go
@@ -130,7 +130,7 @@ func AttachToBug(bugNum int, apiKey string, attachments []Attachment, conf *conf
 			return err
 		}
 		if "yes" == conf.OneCRLVerbose {
-			fmt.Printf("att response %s\n", attResp)
+			fmt.Printf("att response %v\n", attResp)
 		}
 	}
 	return nil
@@ -161,7 +161,7 @@ func AddCommentToBug(bugNum int, conf *config.OneCRLConfig, comment string) erro
 		return err
 	}
 	if "yes" == conf.OneCRLVerbose {
-		fmt.Printf("comment response %s\n", commentResp)
+		fmt.Printf("comment response %v\n", commentResp)
 	}
 	return nil
 }

--- a/certdata/certdata_test.go
+++ b/certdata/certdata_test.go
@@ -267,13 +267,13 @@ func BenchmarkCertdata(b *testing.B) {
 	b.StopTimer()
 	r, err := http.Get(URL)
 	if err != nil || r.StatusCode != http.StatusOK {
-		b.Log("Problem fetching certdata.txt data from %s, status code %s, error %s\n", URL, r.StatusCode, err)
+		b.Logf("Problem fetching certdata.txt data from %s, status code %d, error %s\n", URL, r.StatusCode, err)
 		b.FailNow()
 	}
 	c, err := ioutil.ReadAll(r.Body)
 	r.Body.Close()
 	if err != nil {
-		b.Log("Problem reading from the response body. Got %v, error %v", c, err)
+		b.Logf("Problem reading from the response body. Got %v, error %v", c, err)
 		b.FailNow()
 	}
 	b.StartTimer()

--- a/cmd/certdataDiffCCADB/main.go
+++ b/cmd/certdataDiffCCADB/main.go
@@ -215,7 +215,7 @@ func serve() {
 		log.Fatal(err)
 	}
 	// 20 per minute, with a burst of 5.
-	quota := throttled.RateQuota{throttled.PerMin(20), 5}
+	quota := throttled.RateQuota{MaxRate: throttled.PerMin(20), MaxBurst: 5}
 	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/certdataDiffCCADB/main.go
+++ b/cmd/certdataDiffCCADB/main.go
@@ -68,7 +68,7 @@ func CCADBReader() io.ReadCloser {
 		// get the stream from a file
 		stream, err := os.Open(ccadbPath)
 		if err != nil {
-			log.Fatal("Problem loading CCADB data from file %s\n", err)
+			log.Fatalf("Problem loading CCADB data from file %s\n", err)
 		}
 		return stream
 	} else {
@@ -76,7 +76,7 @@ func CCADBReader() io.ReadCloser {
 		// get the stream from URL
 		r, err := getFromURL(ccadbURL)
 		if err != nil {
-			log.Fatal("Problem fetching CCADB data from URL %s\n", err)
+			log.Fatalf("Problem fetching CCADB data from URL %s\n", err)
 		}
 		return r
 	}
@@ -92,7 +92,7 @@ func CertdataReader() io.ReadCloser {
 		// get the stream from a file
 		stream, err := os.Open(certdataPath)
 		if err != nil {
-			log.Fatal("Problem loading certdata.txt data from file %s\n", err)
+			log.Fatalf("Problem loading certdata.txt data from file %s\n", err)
 		}
 		return stream
 	} else {
@@ -100,7 +100,7 @@ func CertdataReader() io.ReadCloser {
 		r, err := getFromURL(certdataURL)
 		// get the stream from URL
 		if err != nil {
-			log.Fatal("Problem fetching certdata.txt data from URL %s\n", err)
+			log.Fatalf("Problem fetching certdata.txt data from URL %s\n", err)
 		}
 		return r
 	}

--- a/observatory/observatory.go
+++ b/observatory/observatory.go
@@ -31,7 +31,7 @@ type Certificate struct {
     Raw                string
     CA                 bool      `json:"ca"`
     CiscoUmbrellaRank  int       `json:"ciscoUmbrellaRank"`
-    firstSeenTimestamp time.Time `json:"firstSeenTimestamp"`
+    FirstSeenTimestamp time.Time `json:"firstSeenTimestamp"`
     Hashes             struct {
         PinSHA256         string `json:"pin-sha256"`
         SHA1              string `json:"sha1"`
@@ -73,7 +73,7 @@ type Certificate struct {
 // Organization represents an issuer/subject object.
 type Organization struct {
     C  []string `json:"c"`
-    CN string   `json:cn`
+    CN string   `json:"cn"`
     O  []string `json:"o"`
     OU []string `json:"ou"`
 }

--- a/salesforce2OneCRL/salesforce2OneCRL.go
+++ b/salesforce2OneCRL/salesforce2OneCRL.go
@@ -135,7 +135,7 @@ func main() {
 				buf := new(bytes.Buffer)
 				_, err = buf.ReadFrom(res.Body)
 				if err != nil {
-					fmt.Println("Problem reading the CRL data at %s\n", CRLLocation)
+					fmt.Printf("Problem reading the CRL data at %s\n", CRLLocation)
 					continue
 				}
 				crlData := buf.Bytes()

--- a/util/exceptions.go
+++ b/util/exceptions.go
@@ -15,7 +15,10 @@ import (
 )
 
 func getDataFromURL(url string) ([]byte, error) {
-  r, _ := http.Get(url)
+  r, err := http.Get(url)
+  if err != nil {
+    return nil, err
+  }
   defer r.Body.Close()
 
   return ioutil.ReadAll(r.Body)


### PR DESCRIPTION
These are non-functional changes, except for an unexported JSON field that looks harmless. These fix `go test` and `go vet` for 1.11.