### PR TITLE
20180904 lambda config changes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -40,6 +40,7 @@ type OneCRLConfig struct {
 	KintoUser          string `mapstructure:"kintouser"`
 	KintoPassword      string `mapstructure:"kintopass"`
 	KintoCollectionURL string `mapstructure:"collectionurl"`
+	AdditionalConfig   map[string]string
 }
 
 func (config OneCRLConfig) GetRecordURLForEnv(environment string) (error, string) {
@@ -109,10 +110,15 @@ func (config *OneCRLConfig) loadConfig() error {
 	}
 
 	// Loop over the unused keys, add them to extra config
-
-	fmt.Printf("The unmarshalled config is %v\n\n", loaded)
 	if len(md.Unused) > 0 {
-		fmt.Printf("***Some items were left in the map: %v\n\n\n", md.Unused)
+		if nil == config.AdditionalConfig {
+			config.AdditionalConfig = make(map[string]string)
+		}
+
+		for _, key := range md.Unused {
+			fmt.Printf("Key is %v\n", key)
+			config.AdditionalConfig[key] = config_map[key]
+		}
 	}
 
 	// Check the config values to see if any are already overridden


### PR DESCRIPTION
These changes allow services operations to have a single lambda package for different environments by allowing the OneCRL config and the salesforce2OneCRL exceptions to be set from AWS environment. This change includes some modification to config.go to allow configuration entries that do not apply to all OneCRL tools to nevertheless be added to the config.yaml