### PR TITLE
Fix Bugzilla bug creation in salesforce2OneCRL

### DIFF
--- a/bugs/bugs.go
+++ b/bugs/bugs.go
@@ -41,6 +41,7 @@ type Bug struct {
 	Product     string `json:"product"`
 	Component   string `json:"component"`
 	Version     string `json:"version"`
+	Type        string `json:"type"`
 	Summary     string `json:"summary"`
 	Comment     string `json:"comment"`
 	Description string `json:"description"`

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,10 @@ const RecordsPathSuffix string = "/collections/onecrl/records"
 const PREFIX_BUGZILLA_PROD string = "https://bugzilla.mozilla.org"
 const PREFIX_BUGZILLA_STAGE string = "https://bugzilla.allizom.org"
 
+const DEFAULT_BUG_PRODUCT string = "Toolkit"
+const DEFAULT_BUG_COMPONENT string = "Blacklisting"
+const DEFAULT_BUG_VERSION string = "unspecified"
+
 type OneCRLConfig struct {
 	oneCRLConfig       string
 	oneCRLEnvString    string `mapstructure:"onecrlenv"`
@@ -33,6 +37,9 @@ type OneCRLConfig struct {
 	BugzillaBase       string `mapstructure:"bugzilla"`
 	BugzillaAPIKey     string `mapstructure:"bzapikey"`
 	BugzillaReviewers  string `mapstructure:"reviewers"`
+	BugProduct         string `mapstructure:"bugproduct"`
+	BugComponent       string `mapstructure:"bugcomponent"`
+	BugVersion         string `mapstructure:"bugversion"`
 	BugzillaBlockee    string `mapstructure:"blockee"`
 	BugDescription     string `mapstructure:"bugdescription"`
 	Preview            string `mapstructure:"preview"`
@@ -149,6 +156,18 @@ func (config *OneCRLConfig) loadConfig() error {
 			config.BugzillaAPIKey = os.Getenv("bzapikey")
 		}
 	}
+	
+	//Bug report settings
+	if config.BugProduct == DEFAULT_BUG_PRODUCT && loaded.BugProduct != "" {
+		config.BugProduct = loaded.BugProduct
+	}
+	if config.BugComponent == DEFAULT_BUG_COMPONENT && loaded.BugComponent != "" {
+		config.BugComponent = loaded.BugComponent
+	}
+	if config.BugVersion == DEFAULT_BUG_VERSION && loaded.BugVersion != "" {
+		config.BugVersion = loaded.BugVersion
+	}
+
 	if config.BugzillaReviewers == DEFAULT_DEFAULT && loaded.BugzillaReviewers != "" {
 		config.BugzillaReviewers = loaded.BugzillaReviewers
 	}
@@ -223,6 +242,9 @@ func DefineFlags() {
 	flag.StringVar(&conf.OneCRLVerbose, "onecrlverbose", DEFAULT_ONECRLVERBOSE, "Be verbose about OneCRL stuff")
 	flag.StringVar(&conf.BugzillaBase, "bugzilla", PREFIX_BUGZILLA_PROD, "The bugzilla instance to use by default")
 	flag.StringVar(&conf.BugzillaAPIKey, "bzapikey", DEFAULT_DEFAULT, "The bugzilla API key")
+	flag.StringVar(&conf.BugProduct, "bugproduct", DEFAULT_BUG_PRODUCT, "The defualt product of the bug")
+	flag.StringVar(&conf.BugComponent, "bugcomponent", DEFAULT_BUG_COMPONENT, "The defualt product component of the bug")
+	flag.StringVar(&conf.BugVersion, "bugversion", DEFAULT_BUG_VERSION, "The defualt component version of the bug")
 	flag.StringVar(&conf.BugzillaReviewers, "reviewers", DEFAULT_DEFAULT, "The reviewers for the buzilla attachmenets")
 	flag.StringVar(&conf.BugzillaBlockee, "blockee", DEFAULT_DEFAULT, "What bugzilla bug should this bug block")
 	flag.StringVar(&conf.BugDescription, "bugdescription", DEFAULT_DESCRIPTION, "The bugzilla comment to put in the bug")

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ const PREFIX_BUGZILLA_PROD string = "https://bugzilla.mozilla.org"
 const PREFIX_BUGZILLA_STAGE string = "https://bugzilla.allizom.org"
 
 const DEFAULT_BUG_PRODUCT string = "Toolkit"
-const DEFAULT_BUG_COMPONENT string = "Blacklisting"
+const DEFAULT_BUG_COMPONENT string = "Blocklisting"
 const DEFAULT_BUG_VERSION string = "unspecified"
 
 type OneCRLConfig struct {

--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -473,6 +473,7 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 
 	// File a bugzilla bug - so we've got a bug URL to add to the kinto entries
 	if shouldWrite && !conf.SkipBugzilla {
+		fmt.Printf("Adding buzilla record!\n")
 		bug := bugs.Bug{}
 		bug.ApiKey = conf.BugzillaAPIKey
 		blocks, err := strconv.Atoi(conf.BugzillaBlockee)

--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -482,16 +482,19 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 				bug.Blocks = append(bug.Blocks, blocks)
 			}
 		}
-		bug.Product = "Toolkit"
-		bug.Component = "Blocklist Policy Requests"
-		bug.Version = "unspecified"
+		//bug.Component = "Blocklist Policy Requests"
+		bug.Product = conf.BugProduct
+		bug.Component = conf.BugComponent
+		bug.Version = conf.BugVersion
 		bug.Summary = fmt.Sprintf("CCADB entries generated %s", nowString)
 		bug.Description = conf.BugDescription
+		bug.Type = "task"
 
 		bugNum, err = bugs.CreateBug(bug, conf)
 		if err != nil {
 			panic(err)
 		}
+		fmt.Printf("Added bug: %d\n", bugNum)
 	}
 
 	for _, record := range records.Data {

--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -461,6 +461,7 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 	nowString := now.Format("2006-01-02T15:04:05Z")
 
 	// Check that we're correctly authenticated to Kinto
+	/*
 	if shouldWrite {
 		err := checkKintoAuth(conf.KintoCollectionURL)
 
@@ -468,6 +469,7 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 			return err
 		}
 	}
+	*/
 
 	// File a bugzilla bug - so we've got a bug URL to add to the kinto entries
 	if shouldWrite && !conf.SkipBugzilla {

--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -461,7 +461,6 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 	nowString := now.Format("2006-01-02T15:04:05Z")
 
 	// Check that we're correctly authenticated to Kinto
-	/*
 	if shouldWrite {
 		err := checkKintoAuth(conf.KintoCollectionURL)
 
@@ -469,11 +468,9 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 			return err
 		}
 	}
-	*/
 
 	// File a bugzilla bug - so we've got a bug URL to add to the kinto entries
 	if shouldWrite && !conf.SkipBugzilla {
-		fmt.Printf("Adding buzilla record!\n")
 		bug := bugs.Bug{}
 		bug.ApiKey = conf.BugzillaAPIKey
 		blocks, err := strconv.Atoi(conf.BugzillaBlockee)
@@ -482,7 +479,6 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 				bug.Blocks = append(bug.Blocks, blocks)
 			}
 		}
-		//bug.Component = "Blocklist Policy Requests"
 		bug.Product = conf.BugProduct
 		bug.Component = conf.BugComponent
 		bug.Version = conf.BugVersion

--- a/salesforce2OneCRL/salesforce2OneCRL.go
+++ b/salesforce2OneCRL/salesforce2OneCRL.go
@@ -248,7 +248,13 @@ func main() {
 	for _, addition := range additions.Data {
 		fmt.Printf("Mocking addition of entry to OneCRL.\n")
 		fmt.Printf("%s\n", addition)
-		fmt.Printf("Only need to do one. Exiting..\n")
+
+		err = oneCRL.AddEntries(additions, existing, true, comment)
+		if nil != err {
+			panic(err)
+		}
+
+		fmt.Printf("salesforce2OneCRL: Only adding one entry. Exiting..\n")
 		os.Exit(0)
 	}
 

--- a/salesforce2OneCRL/salesforce2OneCRL.go
+++ b/salesforce2OneCRL/salesforce2OneCRL.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mozilla/OneCRL-Tools/config"
 	"github.com/mozilla/OneCRL-Tools/oneCRL"
 	"github.com/mozilla/OneCRL-Tools/salesforce"
-	//"github.com/mozilla/OneCRL-Tools/util"
+	"github.com/mozilla/OneCRL-Tools/util"
 )
 
 const DEFAULT_EXCEPTIONS string = "exceptions.json"
@@ -87,7 +87,7 @@ func main() {
 		stream = r.Body
 	}
 
-	/*
+	///*
 	existing, err := oneCRL.FetchExistingRevocations(conf.KintoCollectionURL + "/records")
 	if nil != err {
 		fmt.Printf("%s\n", err)
@@ -98,7 +98,7 @@ func main() {
 			panic(err)
 		}
 	}
-	*/
+	//*/
 
 	row := 1
 	revoked := salesforce.FetchRevokedCertInfo(stream)
@@ -128,13 +128,11 @@ func main() {
 
 			serialString := base64.StdEncoding.EncodeToString(serialBytes[2:])
 
-			/*
 			record := oneCRL.Record{IssuerName: issuerString, SerialNumber: serialString}
 			if util.RecordExists(record, existing) {
 				fmt.Printf("(%d, %s, %s) revocation already in OneCRL\n", row, each.CSN, each.CertName)
 				continue
 			}
-			*/
 
 			matchFound := false
 			lineErrors := ""
@@ -245,6 +243,13 @@ func main() {
 			rec.Enabled = true
 			additions.Data = append(additions.Data, rec)
 		}
+	}
+
+	for _, addition := range additions.Data {
+		fmt.Printf("Mocking addition of entry to OneCRL.\n")
+		fmt.Printf("%s\n", addition)
+		fmt.Printf("Only need to do one. Exiting..\n")
+		os.Exit(0)
 	}
 
 	/*

--- a/salesforce2OneCRL/salesforce2OneCRL.go
+++ b/salesforce2OneCRL/salesforce2OneCRL.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mozilla/OneCRL-Tools/config"
 	"github.com/mozilla/OneCRL-Tools/oneCRL"
 	"github.com/mozilla/OneCRL-Tools/salesforce"
-	"github.com/mozilla/OneCRL-Tools/util"
+	//"github.com/mozilla/OneCRL-Tools/util"
 )
 
 const DEFAULT_EXCEPTIONS string = "exceptions.json"
@@ -87,6 +87,7 @@ func main() {
 		stream = r.Body
 	}
 
+	/*
 	existing, err := oneCRL.FetchExistingRevocations(conf.KintoCollectionURL + "/records")
 	if nil != err {
 		fmt.Printf("%s\n", err)
@@ -97,6 +98,7 @@ func main() {
 			panic(err)
 		}
 	}
+	*/
 
 	row := 1
 	revoked := salesforce.FetchRevokedCertInfo(stream)
@@ -126,11 +128,13 @@ func main() {
 
 			serialString := base64.StdEncoding.EncodeToString(serialBytes[2:])
 
+			/*
 			record := oneCRL.Record{IssuerName: issuerString, SerialNumber: serialString}
 			if util.RecordExists(record, existing) {
 				fmt.Printf("(%d, %s, %s) revocation already in OneCRL\n", row, each.CSN, each.CertName)
 				continue
 			}
+			*/
 
 			matchFound := false
 			lineErrors := ""
@@ -243,8 +247,10 @@ func main() {
 		}
 	}
 
+	/*
 	err = oneCRL.AddEntries(additions, existing, true, comment)
 	if nil != err {
 		panic(err)
 	}
+	*/
 }

--- a/salesforce2OneCRL/salesforce2OneCRL.go
+++ b/salesforce2OneCRL/salesforce2OneCRL.go
@@ -87,7 +87,6 @@ func main() {
 		stream = r.Body
 	}
 
-	///*
 	existing, err := oneCRL.FetchExistingRevocations(conf.KintoCollectionURL + "/records")
 	if nil != err {
 		fmt.Printf("%s\n", err)
@@ -98,7 +97,6 @@ func main() {
 			panic(err)
 		}
 	}
-	//*/
 
 	row := 1
 	revoked := salesforce.FetchRevokedCertInfo(stream)
@@ -245,23 +243,8 @@ func main() {
 		}
 	}
 
-	for _, addition := range additions.Data {
-		fmt.Printf("Mocking addition of entry to OneCRL.\n")
-		fmt.Printf("%s\n", addition)
-
-		err = oneCRL.AddEntries(additions, existing, true, comment)
-		if nil != err {
-			panic(err)
-		}
-
-		fmt.Printf("salesforce2OneCRL: Only adding one entry. Exiting..\n")
-		os.Exit(0)
-	}
-
-	/*
 	err = oneCRL.AddEntries(additions, existing, true, comment)
 	if nil != err {
 		panic(err)
 	}
-	*/
 }


### PR DESCRIPTION
Adds the configuration options `bugcomponent`, `bugproduct`, `bugversion` to specify the default bug version, component, and product when creating a bug with Bugzilla.

Fixes bug creation with Bugzilla using the REST API.