### PR TITLE
updating to the new cert_storage backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/target
 *.yml
 *.yml*
 obsDiffCCADB/generated

--- a/one_crl_to_cert_storage/Cargo.lock
+++ b/one_crl_to_cert_storage/Cargo.lock
@@ -447,6 +447,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -508,18 +513,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lmdb-rkv"
-version = "0.11.4"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
- "lmdb-rkv-sys 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-rkv-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "lmdb-rkv-sys"
-version = "0.8.6"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.46 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -662,9 +667,9 @@ dependencies = [
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lmdb-rkv 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-rkv 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)",
- "rkv 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rkv 0.11.0 (git+https://github.com/mozilla/rkv?rev=6a866fdad2ca880df9b87fcbc9921abac1e91914)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -984,16 +989,18 @@ dependencies = [
 
 [[package]]
 name = "rkv"
-version = "0.9.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.11.0"
+source = "git+https://github.com/mozilla/rkv?rev=6a866fdad2ca880df9b87fcbc9921abac1e91914#6a866fdad2ca880df9b87fcbc9921abac1e91914"
 dependencies = [
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bincode 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "id-arena 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lmdb-rkv 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lmdb-rkv 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ordered-float 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1513,6 +1520,7 @@ dependencies = [
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
+"checksum id-arena 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum indexmap 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712d7b3ea5827fcb9d4fda14bf4da5f136f0db2ae9c8f4bd4e2d1c6fde4e6db2"
@@ -1521,8 +1529,8 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 "checksum libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)" = "1a31a0627fdf1f6a39ec0dd577e101440b7db22672c0901fe00a9a6fbb5c24e8"
-"checksum lmdb-rkv 0.11.4 (registry+https://github.com/rust-lang/crates.io-index)" = "e25b4069789bf7ac069d6fd58229f18aec20c6f7cc9173cb731d11c10dbb6b6e"
-"checksum lmdb-rkv-sys 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c60e2728ce41a4d4fa4ccf3d07c105bebf198721117e6328a3cf1cb7e4242c70"
+"checksum lmdb-rkv 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "605061e5465304475be2041f19967a900175ea1b6d8f47fbab84a84fb8c48452"
+"checksum lmdb-rkv-sys 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7982ba0460e939e26a52ee12c8075deab0ebd44ed21881f656841b70e021b7c8"
 "checksum lock_api 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f8912e782533a93a167888781b836336a6ca5da6175c05944c86cf28c31104dc"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
@@ -1570,7 +1578,7 @@ dependencies = [
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 "checksum reqwest 0.9.22 (registry+https://github.com/rust-lang/crates.io-index)" = "2c2064233e442ce85c77231ebd67d9eca395207dec2127fe0bbedde4bd29a650"
-"checksum rkv 0.9.7 (registry+https://github.com/rust-lang/crates.io-index)" = "4f9d6a4dd60be13a62ae1d19df68c0c85d77bbee3749b62bf35c49f207d3d750"
+"checksum rkv 0.11.0 (git+https://github.com/mozilla/rkv?rev=6a866fdad2ca880df9b87fcbc9921abac1e91914)" = "<none>"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"

--- a/one_crl_to_cert_storage/Cargo.toml
+++ b/one_crl_to_cert_storage/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 base64 = "0.10"
-lmdb-rkv = "0.11"
-rkv = "^0.9"
+lmdb-rkv = "0.12.3"
+rkv = { git = "https://github.com/mozilla/rkv", rev="6a866fdad2ca880df9b87fcbc9921abac1e91914", default-features = false }
 error-chain = "0.12.1"
 clap = "2.33.0"
 reqwest = "0.9.22"

--- a/one_crl_to_cert_storage/src/cert_storage/mod.rs
+++ b/one_crl_to_cert_storage/src/cert_storage/mod.rs
@@ -10,13 +10,15 @@ use std::path::PathBuf;
 
 use crate::errors::*;
 use crate::one_crl::OneCRL;
+use rkv::backend::{BackendEnvironmentBuilder, SafeMode};
 
 pub fn write(db_path: PathBuf, onecrl: OneCRL) -> Result<()> {
-    let mut builder = Rkv::environment_builder();
+    let mut builder = Rkv::environment_builder::<SafeMode>();
     builder.set_max_dbs(2);
-    let env = match Rkv::from_env(&db_path, builder) {
+    builder.set_map_size(16777216);
+    let env = match Rkv::from_builder(&db_path, builder) {
         Ok(env) => env,
-        Err(err) => Err(format!("failed to capture the cert_storage database. Is Firefox running? Err: {}", err.to_string()))?
+        Err(err) => Err(format!("failed to capture the cert_storage database. Is Firefox running? Does the profile exist? Err: {}", err.to_string()))?
     };
     let store = match env.open_single("cert_storage", StoreOptions::create()) {
         Ok(store) => store,

--- a/one_crl_to_cert_storage/src/one_crl/mod.rs
+++ b/one_crl_to_cert_storage/src/one_crl/mod.rs
@@ -19,7 +19,7 @@ pub enum Environment {
 
 impl Environment {
     pub fn valid_values() -> Vec<&'static str> {
-        vec!["prod", "production", "stag", "staging"]
+        vec!["prod", "production", "stage", "staging"]
     }
 }
 
@@ -28,7 +28,7 @@ impl From<&str> for Environment {
     fn from(value: &str) -> Self {
         match value {
             "production" | "prod" => Environment::Production,
-            "staging" | "stag" => Environment::Staging,
+            "staging" | "stage" => Environment::Staging,
             _ => panic!(format!("Programming Error: '{}' is not a valid for a OneCRL environment", value))
         }
     }


### PR DESCRIPTION
@mozmark `cert_storage` changed its backend on nightly the other week, so we need to update to the specific version of `rkv` used by [Firefox](https://searchfox.org/mozilla-central/source/security/manager/ssl/cert_storage/Cargo.toml), which includes some minor code changes due to interface drift.

I also took the opportunity to .gitignore `target/` and to update the CLI `env` flag to look like the existing tools. I aim to have something on the Python side to call this tool by this weekend's end.