### PR TITLE
Update default bug component and bug attachment flag name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ const PREFIX_BUGZILLA_PROD string = "https://bugzilla.mozilla.org"
 const PREFIX_BUGZILLA_STAGE string = "https://bugzilla.allizom.org"
 
 const DEFAULT_BUG_PRODUCT string = "Toolkit"
-const DEFAULT_BUG_COMPONENT string = "Blocklisting"
+const DEFAULT_BUG_COMPONENT string = "Blocklist Policy Requests"
 const DEFAULT_BUG_VERSION string = "unspecified"
 
 type OneCRLConfig struct {

--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -604,7 +604,7 @@ func AddEntries(records *Records, existing *Records, createBug bool, comment str
 			trimmedReviewer := strings.Trim(reviewer, " ")
 			if len(trimmedReviewer) > 0 {
 				flag := bugs.AttachmentFlag{}
-				flag.Name = "review"
+				flag.Name = "data-review"
 				flag.Status = "?"
 				flag.Requestee = trimmedReviewer
 				flag.New = true


### PR DESCRIPTION
- Updates default configuration options to be compatible with production bugzilla.
- Updates the default flag name when adding bug attachments to bugzilla. @wthayer 