### PR TITLE
20200215 Fix issue #147

### DIFF
--- a/oneCRL/oneCRL.go
+++ b/oneCRL/oneCRL.go
@@ -308,8 +308,12 @@ func LoadRevocationsTxtFromFile(filename string, loader OneCRLLoader) error {
 			continue
 		}
 		if 0 == strings.Index(line, "\t") {
-			log.Fatal("revocations.txt containing subject / pubkey pairs not yet supported")
-			log.Fatal("A public key hash with no subject is not valid. Exiting.")
+			if len(dn) == 0 {
+				log.Fatal("A public key hash with no subject is not valid. Exiting.")
+			}
+			record := Record{Subject: dn, PubKeyHash: strings.Trim(line, "\t")}
+			loader.LoadRecord(record)
+			continue
 		}
 		dn = line
 	}

--- a/oneCRL2CSV/main.go
+++ b/oneCRL2CSV/main.go
@@ -38,20 +38,33 @@ type OneCRLPrinter struct {
 
 func (p OneCRLPrinter) LoadRecord(record oneCRL.Record) {
 	var (
-		issuer string
-		serial string
-		err    error
+		issuer  string
+		serial  string
+		subject string
+		pubkey  string
+		err     error
 	)
-	issuer, err = oneCRL.DNToRFC4514(record.IssuerName)
-	if nil != err {
-		log.Print(err)
+
+	if record.IssuerName == "" && record.SerialNumber == "" {
+		subject, err = oneCRL.DNToRFC4514(record.Subject)
+		if nil != err {
+			log.Print(err)
+		}
+
+		pubkey = record.PubKeyHash
+	} else {
+		issuer, err = oneCRL.DNToRFC4514(record.IssuerName)
+		if nil != err {
+			log.Print(err)
+		}
+
+		serial, err = oneCRL.SerialToString(record.SerialNumber, p.separate, p.upper)
+		if nil != err {
+			log.Print(err)
+		}
 	}
 
-	serial, err = oneCRL.SerialToString(record.SerialNumber, p.separate, p.upper)
-	if nil != err {
-		log.Print(err)
-	}
-	fmt.Printf("\"%s\",\"%s\"\n", issuer, serial)
+	fmt.Printf("\"%s\",\"%s\",\"%s\",\"%s\"\n", issuer, serial, subject, pubkey)
 }
 
 func main() {


### PR DESCRIPTION
This change updates oneCRL.go so that LoadRevocationsTxtFromFile now supports subject / public key hash pairs in revocations.txt files.