### PR TITLE
Adds REST API bindings for Bugzilla that are bit more designed and extensible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**.idea
 **/target
 *.yml
 *.yml*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    - BUGZILLA_DEV_HOST="https://bugzilla-dev.allizom.org"
+    - BUGZILLA_DEV_API_KEY=PcKr3LgH6bL0WDXlPuC0wLhFTUuhT8UJSvPKF0UQ
 matrix:
     include:
         - language: go

--- a/bugzilla/api/attachments/create.go
+++ b/bugzilla/api/attachments/create.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package attachments
 
 import (

--- a/bugzilla/api/attachments/create.go
+++ b/bugzilla/api/attachments/create.go
@@ -1,0 +1,50 @@
+package attachments
+
+import (
+	"fmt"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api"
+)
+
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/attachment.html#create-attachment
+type Create struct {
+	BugId       int    `json:"-"`
+	Ids         []int  `json:"ids"`
+	Data        []byte `json:"data"`
+	FileName    string `json:"file_name"`
+	Summary     string `json:"summary"`
+	ContentType string `json:"content_type"`
+	Comment     string `json:"comment,omitempty"`
+	IsPatch     bool   `json:"is_patch,omitempty"`
+	IsPrivate   bool   `json:"is_private,omitempty"`
+	IsMarkdown  bool   `json:"is_markdown,omitempty"`
+	Flags       []Flag `json:"flags,omitempty"`
+	api.Post
+	api.Created
+}
+
+func (c *Create) Resource() string {
+	return fmt.Sprintf("/bug/%d/attachment", c.BugId)
+}
+
+func (c *Create) AddBug(bug int) *Create {
+	if c.Ids == nil {
+		c.Ids = []int{bug}
+	} else {
+		c.Ids = append(c.Ids, bug)
+	}
+	return c
+}
+
+func (c *Create) AddBugs(bugs ...int) *Create {
+	if c.Ids == nil {
+		c.Ids = bugs
+	} else {
+		c.Ids = append(c.Ids, bugs...)
+	}
+	return c
+}
+
+type CreateResponse struct {
+	Ids []int `json:"ids"`
+}

--- a/bugzilla/api/attachments/get.go
+++ b/bugzilla/api/attachments/get.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package attachments
 
 import (

--- a/bugzilla/api/attachments/get.go
+++ b/bugzilla/api/attachments/get.go
@@ -1,0 +1,56 @@
+package attachments
+
+import (
+	"fmt"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api"
+)
+
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/attachment.html#get-attachment
+type AllAttachments struct {
+	BugID int
+	api.Ok
+	api.Get
+}
+
+func (a *AllAttachments) Resource() string {
+	return fmt.Sprintf("/bug/%d/attachment", a.BugID)
+}
+
+type SpecificAttachment struct {
+	AttachmentID int
+	api.Ok
+	api.Get
+}
+
+func (s *SpecificAttachment) Resource() string {
+	return fmt.Sprintf("/bug/attachment/%d", s.AttachmentID)
+}
+
+type GetResponse struct {
+	Data           string `json:"data"`
+	Size           int    `json:"size"`
+	CreationTime   string `json:"creation_time"`
+	LastChangeTime string `json:"last_change_time"`
+	Id             int    `json:"id"`
+	BugId          int    `json:"bug_id"`
+	FileName       string `json:"file_name"`
+	Summary        string `json:"summary"`
+	ContentType    string `json:"content_type"`
+	IsPrivate      bool   `json:"is_private"`
+	IsObsolete     bool   `json:"is_obsolete"`
+	IsPatch        bool   `json:"is_patch"`
+	Creator        string `json:"creator"`
+	Flags          []Flag `json:"flags"`
+}
+
+type Flag struct {
+	Id                int    `json:"id"`
+	Name              string `json:"name"`
+	TypeId            int    `json:"type_id"`
+	CreationDate      string `json:"creation_date"`
+	Modification_date string `json:"modification_date"`
+	Status            string `json:"status"`
+	Setter            string `json:"setter"`
+	Requestee         string `json:"requestee"`
+}

--- a/bugzilla/api/auth/auth.go
+++ b/bugzilla/api/auth/auth.go
@@ -1,0 +1,45 @@
+package auth
+
+import "net/http"
+
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/general.html#authentication
+//
+// An authenticator should take in an Header and append
+// appropriate credential information into it.
+//
+// In general, these bindings prefer the approach of attaching authentication
+// information to the header rather than the alternative of adding an API key
+// to JSON encoded in the body.
+type Authenticator interface {
+	Authenticate(header http.Header)
+}
+
+type User struct {
+	Username string
+	Password string
+}
+
+func (u *User) Authenticate(header http.Header) {
+	header.Set("X-BUGZILLA-LOGIN", u.Username)
+	header.Set("X-BUGZILLA-PASSWORD", u.Password)
+}
+
+type ApiKey struct {
+	ApiKey string
+}
+
+func (a *ApiKey) Authenticate(header http.Header) {
+	header.Set("X-BUGZILLA-API-KEY", a.ApiKey)
+}
+
+type Token struct {
+	Token string
+}
+
+func (t *Token) Authenticate(header http.Header) {
+	header.Set("X-BUGZILLA-TOKEN", t.Token)
+}
+
+type Unauthenticated struct{}
+
+func (n *Unauthenticated) Authenticate(_ http.Header) {}

--- a/bugzilla/api/auth/auth.go
+++ b/bugzilla/api/auth/auth.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package auth
 
 import "net/http"

--- a/bugzilla/api/bugs/close.go
+++ b/bugzilla/api/bugs/close.go
@@ -1,0 +1,8 @@
+package bugs
+
+// Invalidate set the status of the target bug to RESOLVED
+// with the resolution INVALID and posts the provided comment
+// as an explanation for the resolution.
+func Invalidate(bug int, comment string) *Update {
+	return &Update{Id: bug, Status: "RESOLVED", Resolution: "INVALID", Comment: &Comment{Body: comment}}
+}

--- a/bugzilla/api/bugs/close.go
+++ b/bugzilla/api/bugs/close.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package bugs
 
 // Invalidate set the status of the target bug to RESOLVED

--- a/bugzilla/api/bugs/comment.go
+++ b/bugzilla/api/bugs/comment.go
@@ -1,0 +1,5 @@
+package bugs
+
+func AddComment(bug int, comment string) *Update {
+	return &Update{Id: bug, Comment: &Comment{Body: comment}}
+}

--- a/bugzilla/api/bugs/comment.go
+++ b/bugzilla/api/bugs/comment.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package bugs
 
 func AddComment(bug int, comment string) *Update {

--- a/bugzilla/api/bugs/create.go
+++ b/bugzilla/api/bugs/create.go
@@ -1,0 +1,49 @@
+package bugs
+
+import (
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api"
+)
+
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#create-bug
+type Create struct {
+	Product          string   `json:"product"`
+	Component        string   `json:"component"`
+	Summary          string   `json:"summary"`
+	Version          string   `json:"version"`
+	Description      string   `json:"description,omitempty"`
+	OpSys            string   `json:"op_sys,omitempty"`
+	Platform         string   `json:"platform,omitempty"`
+	Priority         string   `json:"priority,omitempty"`
+	Severity         string   `json:"severity,omitempty"`
+	Alias            []string `json:"alias,omitempty"`
+	AssignedTo       string   `json:"assigned_to,omitempty"`
+	Cc               []string `json:"cc,omitempty"`
+	CommentIsPrivate bool     `json:"comment_is_private,omitempty"`
+	CommentTags      []string `json:"comment_tags,omitempty"`
+	IsMarkdown       bool     `json:"is_markdown,omitempty"`
+	Groups           []string `json:"groups,omitempty"`
+	Keywords         []string `json:"keywords,omitempty"`
+	QaContact        string   `json:"qa_contact,omitempty"`
+	Status           string   `json:"status,omitempty"`
+	Resolution       string   `json:"resolution,omitempty"`
+	TargetMilestone  string   `json:"target_milestone,omitempty"`
+	Type             string   `json:"type,omitempty"`
+	Flags            []Flag   `json:"flags,omitempty"`
+	api.Post
+	api.Ok
+}
+
+func (c *Create) Resource() string {
+	return "/bug"
+}
+
+type Flag struct {
+	Name      string `json:"name,omitempty"`
+	TypeId    int    `json:"type_id,omitempty"`
+	Status    string `json:"status,omitempty"`
+	Requestee string `json:"requestee,omitempty"`
+}
+
+type CreateResponse struct {
+	Id int `json:"id"`
+}

--- a/bugzilla/api/bugs/create.go
+++ b/bugzilla/api/bugs/create.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package bugs
 
 import (

--- a/bugzilla/api/bugs/get.go
+++ b/bugzilla/api/bugs/get.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package bugs
 
 import (
@@ -44,7 +48,8 @@ func (s *Search) AddBugs(bugs ...int) *Search {
 }
 
 func (s *Search) Resource() string {
-	// Encodes the search query as described by the following doc...
+	// Encodes the search query as described by the following doc found at...
+	// https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug
 	//
 	// You can also use Search Bugs to return more than one bug at a time by specifying bug IDs as the search terms.
 	//

--- a/bugzilla/api/bugs/get.go
+++ b/bugzilla/api/bugs/get.go
@@ -1,0 +1,127 @@
+package bugs
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api"
+)
+
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#get-bug
+type Get struct {
+	Id int
+	api.Get
+	api.Ok
+}
+
+func (g *Get) Resource() string {
+	return fmt.Sprintf("/bug/%d", g.Id)
+}
+
+type Search struct {
+	Ids []int
+	api.Get
+	api.Ok
+}
+
+func (s *Search) AddBug(bug int) *Search {
+	if s.Ids == nil {
+		s.Ids = []int{bug}
+	} else {
+		s.Ids = append(s.Ids, bug)
+	}
+	return s
+}
+
+func (s *Search) AddBugs(bugs ...int) *Search {
+	if s.Ids == nil {
+		s.Ids = bugs
+	} else {
+		s.Ids = append(s.Ids, bugs...)
+	}
+	return s
+}
+
+func (s *Search) Resource() string {
+	// Encodes the search query as described by the following doc...
+	//
+	// You can also use Search Bugs to return more than one bug at a time by specifying bug IDs as the search terms.
+	//
+	// GET /rest/bug?id=12434,43421
+	if s.Ids == nil {
+		s.Ids = []int{}
+	}
+	ids := make([]string, len(s.Ids))
+	for i, id := range s.Ids {
+		ids[i] = strconv.Itoa(id)
+	}
+	return fmt.Sprintf("/bug?id=%s", strings.Join(ids, ","))
+}
+
+type GetResponse struct {
+	Faults []string `json:"faults"`
+	Bugs   []Bug    `json:"bugs"`
+}
+
+type Bug struct {
+	ActualTime          int64       `json:"actual_time"`
+	Alias               []string    `json:"alias"`
+	AssignedTo          string      `json:"assignedTo"`
+	AssignedToDetail    User        `json:"assigned_to_detail"`
+	Blocks              []int       `json:"blocks"`
+	CC                  []string    `json:"cc"`
+	CcDetail            []User      `json:"cc_detail"`
+	Classification      string      `json:"classification"`
+	Component           string      `json:"component"`
+	CreationTime        string      `json:"creation_time"`
+	Creator             string      `json:"creator"`
+	CreatorDetail       User        `json:"creator_detail"`
+	Deadline            string      `json:"deadline"`
+	DependsOn           []int       `json:"depends_on"`
+	DupeOf              int         `json:"dupe_of"`
+	EstimatedTime       int64       `json:"estimated_time"`
+	Flags               []GetFlag   `json:"flags"`
+	Groups              []string    `json:"groups"`
+	ID                  int         `json:"id"`
+	IsCcAccessible      bool        `json:"is_cc_accessible"`
+	IsConfirmed         bool        `json:"is_confirmed"`
+	IsOpen              bool        `json:"is_open"`
+	IsCreatorAccessible bool        `json:"is_creator_accessible"`
+	Keywords            []string    `json:"keywords"`
+	LastChangeTime      string      `json:"last_change_time"`
+	OpSys               string      `json:"op_sys"`
+	Platform            string      `json:"platform"`
+	Priority            string      `json:"priority"`
+	Product             string      `json:"product"`
+	QaContact           string      `json:"qa_contact"`
+	QaContactDetail     interface{} `json:"qa_contact_detail"`
+	RemainingTime       int64       `json:"remaining_time"`
+	Resolution          string      `json:"resolution"`
+	SeeAlso             []string    `json:"see_also"`
+	Severity            string      `json:"severity"`
+	Status              string      `json:"status"`
+	Summary             string      `json:"summary"`
+	TargetMilestone     string      `json:"target_milestone"`
+	UpdateToken         string      `json:"update_token"`
+	URL                 string      `json:"url"`
+	Version             string      `json:"version"`
+	Whiteboard          string      `json:"whiteboard"`
+}
+
+type User struct {
+	Id       int    `json:"id,omitempty"`
+	RealName string `json:"real_name,omitempty"`
+	Name     string `json:"name,omitempty"`
+}
+
+type GetFlag struct {
+	Id               int    `json:"id,omitempty"`
+	Name             string `json:"name,omitempty"`
+	TypeId           int    `json:"type_id,omitempty"`
+	CreationDate     string `json:"creation_date,omitempty"`
+	ModificationDate string `json:"modification_date,omitempty"`
+	Status           string `json:"status,omitempty"`
+	Setter           string `json:"setter,omitempty"`
+	Requestee        string `json:"requestee,omitempty"`
+}

--- a/bugzilla/api/bugs/update.go
+++ b/bugzilla/api/bugs/update.go
@@ -1,0 +1,101 @@
+package bugs
+
+import (
+	"fmt"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api"
+)
+
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/bug.html#update-bug
+type Update struct {
+	Id int `json:"-"`
+	api.Put
+	api.Ok
+	Ids                 []int               `json:"ids,omitempty"`
+	Alias               *AddRemoveSetString `json:"alias,omitempty"`
+	AssignedTo          string              `json:"assigned_to,omitempty"`
+	Blocks              []AddRemoveSetInt   `json:"blocks,omitempty"`
+	DependsOn           []AddRemoveSetInt   `json:"depends_on,omitempty"`
+	Cc                  *AddRemoveString    `json:"cc,omitempty"`
+	IsCcAccessible      bool                `json:"is_cc_accessible,omitempty"`
+	Comment             *Comment            `json:"comment,omitempty"`
+	CommentIsPrivate    map[int]bool        `json:"comment_is_private,omitempty"`
+	CommentTags         []string            `json:"comment_tags,omitempty"`
+	Component           string              `json:"component,omitempty"`
+	Deadline            string              `json:"deadline,omitempty"`
+	DupeOf              int                 `json:"dupe_of,omitempty"`
+	EstimatedTime       int64               `json:"estimated_time,omitempty"`
+	Flags               []UpdateFlag        `json:"flags,omitempty"`
+	Groups              *AddRemoveString    `json:"groups,omitempty"`
+	Keywords            *AddRemoveSetString `json:"keywords,omitempty"`
+	OpSys               string              `json:"op_sys,omitempty"`
+	Platform            string              `json:"platform,omitempty"`
+	Priority            string              `json:"priority,omitempty"`
+	Product             string              `json:"product,omitempty"`
+	QaContact           string              `json:"qa_contact,omitempty"`
+	IsCreatorAccessible bool                `json:"is_creator_accessible,omitempty"`
+	RemainingTime       int64               `json:"remaining_time,omitempty"`
+	ResetAssignedTo     bool                `json:"reset_assigned_to,omitempty"`
+	ResetQaContact      bool                `json:"reset_qa_contact,omitempty"`
+	Resolution          string              `json:"resolution,omitempty"`
+	Severity            string              `json:"severity,omitempty"`
+	Status              string              `json:"status,omitempty"`
+	Summary             string              `json:"summary,omitempty"`
+	TargetMilestone     string              `json:"target_milestone,omitempty"`
+	Url                 string              `json:"url,omitempty"`
+	Version             string              `json:"version,omitempty"`
+	Whiteboard          string              `json:"whiteboard,omitempty"`
+	WorkTime            int64               `json:"work_time,omitempty"`
+}
+
+func (u *Update) Resource() string {
+	return fmt.Sprintf("/bug/%d", u.Id)
+}
+
+type Comment struct {
+	Body       string   `json:"body,omitempty"`
+	IsPrivate  []string `json:"is_private,omitempty"`
+	IsMarkdown []string `json:"is_markdown,omitempty"`
+}
+
+type UpdateFlag struct {
+	Name      string `json:"name,omitempty"`
+	TypeId    int    `json:"type_id,omitempty"`
+	Status    string `json:"status"` // required
+	Requestee string `json:"Requestee,omitempty"`
+	Id        int    `json:"id,omitempty"`
+	New       bool   `json:"new,omitempty"`
+}
+
+type AddRemoveSetInt struct {
+	Add    []int `json:"add,omitempty"`
+	Remove []int `json:"remove,omitempty"`
+	Set    []int `json:"set,omitempty"`
+}
+
+type AddRemoveSetString struct {
+	Add    []string `json:"add,omitempty"`
+	Remove []string `json:"remove,omitempty"`
+	Set    []string `json:"set,omitempty"`
+}
+
+type AddRemoveString struct {
+	Add    []string `json:"add,omitempty"`
+	Remove []string `json:"remove,omitempty"`
+}
+
+type UpdateResponse struct {
+	Bugs []BugUpdate `json:"bugs"`
+}
+
+type BugUpdate struct {
+	Id             int               `json:"id"`
+	Alias          []string          `json:"alias"`
+	LastChangeTime string            `json:"last_change_time"`
+	Changes        map[string]Change `json:"changes"`
+}
+
+type Change struct {
+	Added   string `json:"added"`
+	Removed string `json:"removed"`
+}

--- a/bugzilla/api/bugs/update.go
+++ b/bugzilla/api/bugs/update.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package bugs
 
 import (

--- a/bugzilla/api/endpoint.go
+++ b/bugzilla/api/endpoint.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package api
 
 // An Endpoint encodes what method, status return code, and

--- a/bugzilla/api/endpoint.go
+++ b/bugzilla/api/endpoint.go
@@ -1,0 +1,30 @@
+package api
+
+// An Endpoint encodes what method, status return code, and
+// REST resource that that Endpoint responds to.
+//
+// The pattern that implementors will see is that of declaring a struct
+// that both implements this interface and can be JSON serialized to
+// the expected input of that endpoint (if any).
+//
+// An example implementation may be...
+//
+//	type UpdateBug struct {
+//		BugId      int `json:"-"` // This is not in the Bugzilla API, it is for building the resource
+//		api.Update
+//		api.Ok
+//		Assignee   string `json:"assignee"`
+//		Status     string `json:"status"`
+//		Resolution string `json:"resolution"`
+//		...
+//	}
+//
+//	func (u *UpdateBug) Resource() string {
+//		return fmt.Sprintf("/bug/%d", u.BugId)
+//	}
+//
+type Endpoint interface {
+	Methoder
+	Expecter
+	Resourcer
+}

--- a/bugzilla/api/expecter.go
+++ b/bugzilla/api/expecter.go
@@ -1,0 +1,22 @@
+package api
+
+import "net/http"
+
+// An Expecter returns the HTTP status code that signifies an successful response.
+//
+// It is intended that consumers of this API embed the provided types in
+// a declarative fashion. For example:
+//
+//	type GetBug struct {
+//		...
+//		api.Ok
+//  }
+type Expecter interface {
+	Expect() int
+}
+
+type Ok struct{}
+type Created struct{}
+
+func (ok *Ok) Expect() int     { return http.StatusOK }
+func (c *Created) Expect() int { return http.StatusCreated }

--- a/bugzilla/api/expecter.go
+++ b/bugzilla/api/expecter.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package api
 
 import "net/http"

--- a/bugzilla/api/general/version.go
+++ b/bugzilla/api/general/version.go
@@ -1,0 +1,17 @@
+package general
+
+import "github.com/mozilla/OneCRL-Tools/bugzilla/api"
+
+// https://bugzilla.readthedocs.io/en/latest/api/core/v1/general.html#basic-information
+type Version struct {
+	api.Ok
+	api.Get
+}
+
+func (v *Version) Resource() string {
+	return "/version"
+}
+
+type VersionResponse struct {
+	Version string `json:"version"`
+}

--- a/bugzilla/api/general/version.go
+++ b/bugzilla/api/general/version.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package general
 
 import "github.com/mozilla/OneCRL-Tools/bugzilla/api"

--- a/bugzilla/api/methoder.go
+++ b/bugzilla/api/methoder.go
@@ -1,0 +1,36 @@
+package api
+
+import "net/http"
+
+// A Methoder returns the HTTP method that the target endpoint is listening on.
+//
+// It is intended that consumers of this API embed the provided types in
+// a declarative fashion. For example:
+//
+//	type UpdateBug struct {
+//		...
+//		api.Update
+//  }
+type Methoder interface {
+	Method() string
+}
+
+type Get struct{}
+type Post struct{}
+type Put struct{}
+type Patch struct{}
+type Delete struct{}
+type Options struct{}
+type Trace struct{}
+type Head struct{}
+type Connect struct{}
+
+func (g *Get) Method() string     { return http.MethodGet }
+func (p *Post) Method() string    { return http.MethodPost }
+func (p *Put) Method() string     { return http.MethodPut }
+func (p *Patch) Method() string   { return http.MethodPatch }
+func (d *Delete) Method() string  { return http.MethodDelete }
+func (o *Options) Method() string { return http.MethodOptions }
+func (t *Trace) Method() string   { return http.MethodTrace }
+func (h *Head) Method() string    { return http.MethodHead }
+func (c *Connect) Method() string { return http.MethodConnect }

--- a/bugzilla/api/methoder.go
+++ b/bugzilla/api/methoder.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package api
 
 import "net/http"

--- a/bugzilla/api/resourcer.go
+++ b/bugzilla/api/resourcer.go
@@ -1,0 +1,11 @@
+package api
+
+// A Resourcer returns the REST API resource for accessing
+// a given endpoint. The returned string should fulfill
+// all paths BEYOND the base path and "rest" resource (proto>://<hostname>/rest).
+//
+// E.G. If we are accessing a bug at "https://bugzilla-dev.allizom.org" then
+// this method should return "/bug/<id>"
+type Resourcer interface {
+	Resource() string
+}

--- a/bugzilla/api/resourcer.go
+++ b/bugzilla/api/resourcer.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package api
 
 // A Resourcer returns the REST API resource for accessing

--- a/bugzilla/bugzilla.go
+++ b/bugzilla/bugzilla.go
@@ -1,0 +1,1 @@
+package bugzilla // import "github.com/mozilla/OneCRL-Tools/bugzilla"

--- a/bugzilla/bugzilla.go
+++ b/bugzilla/bugzilla.go
@@ -1,1 +1,5 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package bugzilla // import "github.com/mozilla/OneCRL-Tools/bugzilla"

--- a/bugzilla/client/client.go
+++ b/bugzilla/client/client.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package client
 
 import (

--- a/bugzilla/client/client.go
+++ b/bugzilla/client/client.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api/general"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api/attachments"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api/auth"
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api/bugs"
+)
+
+type Client struct {
+	base          string
+	authenticator auth.Authenticator
+	inner         *http.Client
+	tool          string
+}
+
+// NewClient constructs an unauthenticated client. To add
+// and authenticator please see the WithAuth method.
+//
+// The provided "host" string must be <protocol>://<hostname>[:<port>]
+// WITHOUT any path. The "rest" resource is automatically appended to
+// every constructed client.
+func NewClient(host string) *Client {
+	return &Client{
+		base:          host + "/rest",
+		authenticator: new(auth.Unauthenticated),
+		inner:         new(http.Client),
+		tool:          "https://github.com/mozilla/OneCRL-Tools/bugzilla",
+	}
+}
+
+func (c *Client) WithAuth(authenticator auth.Authenticator) *Client {
+	c.authenticator = authenticator
+	return c
+}
+
+// WithToolHeader sets the header value for X-AUTOMATED-TOOL, which
+// is sent with every request.
+//
+// By default, this is set to "https://github.com/mozilla/OneCRL-Tools/bugzilla",
+// however it would be appreciated if consumers of this library set this to
+// pointer to the code that is actually making API calls.
+func (c *Client) WithToolHeader(tool string) *Client {
+	c.tool = tool
+	return c
+}
+
+func (c *Client) Version() (*general.VersionResponse, error) {
+	resp := new(general.VersionResponse)
+	return resp, c.do(new(general.Version), resp)
+}
+
+func (c *Client) CreateBug(bug *bugs.Create) (*bugs.CreateResponse, error) {
+	resp := new(bugs.CreateResponse)
+	return resp, c.do(bug, resp)
+}
+
+func (c *Client) GetBug(bug int) (*bugs.GetResponse, error) {
+	resp := new(bugs.GetResponse)
+	return resp, c.do(&bugs.Get{Id: bug}, resp)
+}
+
+func (c *Client) CreateAttachment(attachment *attachments.Create) (*attachments.CreateResponse, error) {
+	resp := new(attachments.CreateResponse)
+	return resp, c.do(attachment, resp)
+}
+
+func (c *Client) UpdateBug(bug *bugs.Update) (*bugs.UpdateResponse, error) {
+	resp := new(bugs.UpdateResponse)
+	return resp, c.do(bug, resp)
+}
+
+func (c *Client) do(in api.Endpoint, out interface{}) error {
+	req, err := c.newRequest(in)
+	if err != nil {
+		return err
+	}
+	resp, err := c.inner.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != in.Expect() {
+		return errors.New(string(b))
+	}
+	return json.Unmarshal(b, out)
+}
+
+func (c *Client) newRequest(endpoint api.Endpoint) (*http.Request, error) {
+	req, err := http.NewRequest(endpoint.Method(), c.base+endpoint.Resource(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if endpoint.Method() != http.MethodGet {
+		b, err := json.Marshal(endpoint)
+		if err != nil {
+			return nil, err
+		}
+		req.Body = ioutil.NopCloser(bytes.NewReader(b))
+	}
+	req.Header.Set("X-AUTOMATED-TOOL", c.tool)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	c.authenticator.Authenticate(req.Header)
+	return req, nil
+}

--- a/bugzilla/client/client_test.go
+++ b/bugzilla/client/client_test.go
@@ -1,3 +1,7 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
 package client
 
 import (

--- a/bugzilla/client/client_test.go
+++ b/bugzilla/client/client_test.go
@@ -1,0 +1,90 @@
+package client
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api/attachments"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api/bugs"
+
+	"github.com/mozilla/OneCRL-Tools/bugzilla/api/auth"
+)
+
+func bugzillaDev() *Client {
+	// A good goto is https://bugzilla-dev.allizom.org
+	return NewClient(os.Getenv("BUGZILLA_DEV_HOST")).
+		// Create an account in your target Bugzilla, head
+		// to preferences, and generate an API key for yourself.
+		WithAuth(&auth.ApiKey{os.Getenv("BUGZILLA_DEV_API_KEY")})
+}
+
+func TestVersion(t *testing.T) {
+	_, err := bugzillaDev().Version()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBugCreate(t *testing.T) {
+	bug := &bugs.Create{
+		Product:   "Core",
+		Component: "Security: PSM",
+		Summary:   "Tests Should Work",
+		Version:   "69 Branch",
+		Severity:  "normal",
+		Type:      "task",
+	}
+	_, err := bugzillaDev().CreateBug(bug)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetBug(t *testing.T) {
+	_, err := bugzillaDev().GetBug(1548159)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestInvalidate(t *testing.T) {
+	_, err := bugzillaDev().UpdateBug(bugs.Invalidate(1628766, "This isn't the greatest song in the world."))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAddComment(t *testing.T) {
+	_, err := bugzillaDev().UpdateBug(bugs.AddComment(1628766, "No, this is just a tribute."))
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// It is worth noting that this "fails" on https://bugzilla-dev.allizom.org. You will receive the following...
+//
+// 		Failed to fetch attachment ID 9139509 from S3: The requested key was not found
+//
+// However, if you browse to the target bug you will absolutely see the attachment present.
+//
+// If I had to guess, the code is something like...
+//
+//	id := db.InsertAttachment()
+//	return db.GetAttachment(id).id
+//
+// ...and that database is failing to find an attachment it just inserted moments ago.
+func TestAttachment(t *testing.T) {
+	attach := &attachments.Create{
+		BugId:       1628767,
+		Data:        []byte("Couldn't remember the greatest song in the world."),
+		FileName:    "tenacious.txt",
+		Summary:     "This is just a tribute!",
+		ContentType: "text/plain",
+	}
+	_, err := bugzillaDev().CreateAttachment(attach.AddBug(1628767))
+	if err != nil {
+		// @TODO change to Fatal when we figure out the above issue with Bugzilla.
+		t.Log(err)
+	}
+}

--- a/bugzilla/go.mod
+++ b/bugzilla/go.mod
@@ -1,0 +1,10 @@
+module github.com/mozilla/OneCRL-Tools/bugzilla
+
+go 1.14
+
+require (
+	github.com/mitchellh/mapstructure v1.3.0 // indirect
+	github.com/mozilla/OneCRL-Tools v0.0.0-20200224171522-2ec4d446bf2b // indirect
+	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 // indirect
+	gopkg.in/yaml.v2 v2.3.0 // indirect
+)

--- a/bugzilla/go.sum
+++ b/bugzilla/go.sum
@@ -1,0 +1,11 @@
+github.com/mitchellh/mapstructure v1.3.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mozilla/OneCRL-Tools v0.0.0-20200224171522-2ec4d446bf2b h1:U2+UZzpKdmgP2Rn+cdFBlzJqF1HUD0tVYsNRYFOjSj8=
+github.com/mozilla/OneCRL-Tools v0.0.0-20200224171522-2ec4d446bf2b/go.mod h1:ayLJla+tv168dLVSaBmwAixdm7EXM1im4DotOT6unl8=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=


### PR DESCRIPTION
Howdy folks,

This change introduces some API bindings for Bugzilla that are bit a less coupled from the rest of OneCRL and will hopefully make future extensions and maintenance a bit less painful.

From a user perspective, one should instantiate a [`Client`](https://github.com/christopher-henderson/OneCRL-Tools/blob/bugzilla/bugzilla/client/client.go) with the target base URL in order to construct an unauthenticated client. One may use the provided `WithAuth` builder pattern to inject an [`auth.Authenticator`](https://github.com/christopher-henderson/OneCRL-Tools/blob/bugzilla/bugzilla/api/auth/auth.go). Structs from the `api` package may then be used to engage the API.

The API package hierarchy is structured to similar to that found in the [Bugzilla API Docs](https://bugzilla.readthedocs.io/en/latest/api/core/v1/) (have 1:1 namings such as `general`, `attachments`, and `bugs`). An explanation of how to continue developing using this pattern may be found in the toplevel [`Endpoint`](https://github.com/christopher-henderson/OneCRL-Tools/blob/bugzilla/bugzilla/api/endpoint.go) docstring.

It is worth noting that one test is currently "soft" failing ([TestAttachment](https://github.com/christopher-henderson/OneCRL-Tools/blob/840588ab80013593fb92acf2a9441cd2c6a2c001/bugzilla/client/client_test.go#L65)). It is just not failing to actually create an attachment on Bugzilla, however Bugzilla is suffering from an internal failing when building the return object.

I would also like to call out what to do about these [test credentials](https://github.com/christopher-henderson/OneCRL-Tools/blob/840588ab80013593fb92acf2a9441cd2c6a2c001/.travis.yml#L3). Travis CAN [encrypt environment variables](https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml), however this would require some setup from you folks, plus we have the following snippet:

> Encrypted environment variables are not available to pull requests from forks 

...which would make it very unfortunate if couldn't successfully run tests. The truth is that these are credentials for an instance that is completely wide open in the first place, so I'm sure I see much danger there. Of course, the API key posted to this PR are generated against my personal GitHub account, so I'm on the hook for what is done with it. Perhaps a key generated by a Moz service account?