### PR TITLE
Initial kinto bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 **.idea
 **/target
-*.yml
-*.yml*
+*config-example.yml
+*config-sample.yml
 obsDiffCCADB/generated

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,12 @@ env:
   global:
     - BUGZILLA_DEV_HOST="https://bugzilla-dev.allizom.org"
     - BUGZILLA_DEV_API_KEY=PcKr3LgH6bL0WDXlPuC0wLhFTUuhT8UJSvPKF0UQ
+    - KINTO_TESTDIR=${TRAVIS_BUILD_DIR}/kinto/local
 matrix:
     include:
         - language: go
+          services:
+            - docker
           go: stable
           install:
                # Handle forks by copying this checkout to the expected fork directory
@@ -20,5 +23,3 @@ matrix:
           script:
               - cd one_crl_to_cert_storage
               - cargo build --verbose
-
-

--- a/kinto/api/auth/auth.go
+++ b/kinto/api/auth/auth.go
@@ -1,0 +1,43 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package auth
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api"
+)
+
+// https://docs.kinto-storage.org/en/stable/api/1.x/authentication.html
+type Authenticator interface {
+	Authenticate(r *http.Request)
+}
+
+type User struct {
+	Username string `json:"-"`
+	Password string `json:"password"`
+	*api.Record
+}
+
+func (u *User) Put() string {
+	return fmt.Sprintf("/accounts/%s", u.Username)
+}
+
+func (u *User) Authenticate(r *http.Request) {
+	r.SetBasicAuth(u.Username, u.Password)
+}
+
+type Token struct {
+	Token string
+}
+
+func (t *Token) Authenticate(header http.Header) {
+	header.Set("Authorization", "Bearer "+t.Token)
+}
+
+type Unauthenticated struct{}
+
+func (n *Unauthenticated) Authenticate(_ *http.Request) {}

--- a/kinto/api/authz/permissions.go
+++ b/kinto/api/authz/permissions.go
@@ -1,0 +1,19 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package authz
+
+// https://docs.kinto-storage.org/en/stable/api/1.x/permissions.html#api-principals
+type Permissions struct {
+	Read  []string `json:"read,omitempty"`
+	Write []string `json:"write,omitempty"`
+}
+
+const (
+	world         = "system.Everyone"
+	authenticated = "system.Authenticated"
+)
+
+var WorldR = &Permissions{Read: []string{world}}
+var WorldRW = &Permissions{Write: []string{world}, Read: []string{world}}

--- a/kinto/api/batch/batch.go
+++ b/kinto/api/batch/batch.go
@@ -30,7 +30,7 @@ func (b *Batch) Post() string {
 	return "/batch"
 }
 
-// NewBatch a Batch whose inner requests are homogenous (Kinto allows for mixing requests
+// NewBatch returns a Batch whose inner requests are homogenous (Kinto allows for mixing requests
 // within batch operations (say, for example, two POSTs of records and one GET of a collection)) however this
 // API does not.
 func NewBatch(records []interface{}, perms *authz.Permissions, method, path string) *Batch {

--- a/kinto/api/batch/batch.go
+++ b/kinto/api/batch/batch.go
@@ -7,9 +7,8 @@ package batch
 import (
 	"math"
 
-	"github.com/mozilla/OneCRL-Tools/kinto/api/authz"
-
 	"github.com/mozilla/OneCRL-Tools/kinto/api"
+	"github.com/mozilla/OneCRL-Tools/kinto/api/authz"
 )
 
 // https://docs.kinto-storage.org/en/stable/api/1.x/batch.html

--- a/kinto/api/batch/batch.go
+++ b/kinto/api/batch/batch.go
@@ -1,0 +1,74 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package batch
+
+import (
+	"math"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/authz"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api"
+)
+
+// https://docs.kinto-storage.org/en/stable/api/1.x/batch.html
+type Batch struct {
+	Defaults *Defaults        `json:"defaults"`
+	Requests []BatchedRequest `json:"requests"`
+}
+
+type BatchedRequest struct {
+	Body *api.Payload `json:"body"`
+}
+
+type Defaults struct {
+	Method string `json:"method"`
+	Path   string `json:"path"`
+}
+
+func (b *Batch) Post() string {
+	return "/batch"
+}
+
+// NewBatch a Batch whose inner requests are homogenous (Kinto allows for mixing requests
+// within batch operations (say, for example, two POSTs of records and one GET of a collection)) however this
+// API does not.
+func NewBatch(records []interface{}, perms *authz.Permissions, method, path string) *Batch {
+	requests := make([]BatchedRequest, len(records))
+	for i, record := range records {
+		requests[i] = BatchedRequest{Body: api.NewPayload(record, perms)}
+	}
+	return &Batch{Defaults: &Defaults{
+		Method: method,
+		Path:   path,
+	}, Requests: requests}
+}
+
+// NewBatches returns a slice of Batch whose inner requests are homogenous (Kinto allows for mixing requests
+// within batch operations (say, for example, two POSTs of records and one GET of a collection)) however this
+// API does not.
+//
+// maxRequest must be less-than-or equal to Kinto's configured "batch_max_requests". See Client.BatchMaxRequests for
+// more information on how to retrieve this value programatically.
+func NewBatches(records []interface{}, maxRequests int, perms *authz.Permissions, method, path string) []*Batch {
+	batches := make([]*Batch, numBatches(len(records), maxRequests))
+	for i := 0; i < len(batches); i++ {
+		start := i * maxRequests
+		end := min(start+maxRequests, len(records))
+		batches[i] = NewBatch(records[start:end], perms, method, path)
+	}
+	return batches
+}
+
+func numBatches(records, maxRequests int) int {
+	return int(math.Ceil(float64(records) / float64(maxRequests)))
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	} else {
+		return b
+	}
+}

--- a/kinto/api/buckets/buckets.go
+++ b/kinto/api/buckets/buckets.go
@@ -1,0 +1,34 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package buckets
+
+import (
+	"fmt"
+)
+
+// https://docs.kinto-storage.org/en/stable/api/1.x/buckets.html
+type Bucket struct {
+	ID string `json:"id"`
+}
+
+func NewBucket(name string) *Bucket {
+	return &Bucket{ID: name}
+}
+
+func (b *Bucket) Get() string {
+	return fmt.Sprintf("/buckets/%s", b.ID)
+}
+
+func (b *Bucket) Post() string {
+	return "/buckets"
+}
+
+func (b *Bucket) Patch() string {
+	return b.Get()
+}
+
+func (b *Bucket) Put() string {
+	return b.Get()
+}

--- a/kinto/api/collections/collections.go
+++ b/kinto/api/collections/collections.go
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package collections
+
+import (
+	"fmt"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/buckets"
+)
+
+// https://docs.kinto-storage.org/en/stable/api/1.x/collections.html
+type Collection struct {
+	ID     string          `json:"id"`
+	Bucket *buckets.Bucket `json:"-"`
+}
+
+func NewCollection(bucket *buckets.Bucket, name string) *Collection {
+	return &Collection{ID: name, Bucket: bucket}
+}
+
+func (c *Collection) Get() string {
+	return fmt.Sprintf("%s/records", c.Patch())
+}
+
+func (c *Collection) Post() string {
+	return fmt.Sprintf("%s/collections", c.Bucket.Get())
+}
+
+func (c *Collection) Patch() string {
+	return fmt.Sprintf("%s/collections/%s", c.Bucket.Get(), c.ID)
+}
+
+func (c *Collection) Put() string {
+	return c.Patch()
+}

--- a/kinto/api/payload.go
+++ b/kinto/api/payload.go
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package api
+
+import (
+	"github.com/mozilla/OneCRL-Tools/kinto/api/authz"
+)
+
+type Payload struct {
+	Data        interface{}        `json:"data"`
+	Permissions *authz.Permissions `json:"permissions,omitempty"`
+}
+
+func NewPayload(data interface{}, perms *authz.Permissions) *Payload {
+	return &Payload{
+		Data:        data,
+		Permissions: perms,
+	}
+}

--- a/kinto/api/record.go
+++ b/kinto/api/record.go
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package api
+
+// Every Record in Kinto has attached to it an ID and last-modified data.
+// The best way to use this struct is to embed a pointer to it within
+// your own schema.
+//
+//     type LegoSet struct {
+//         branding string
+//         legos    []Lego
+//         *api.Record
+//     }
+//
+// This enables you to leave the Kinto metadata out in your in code while
+// receiving it in full from Kinto when using your struct as a serde target.
+//
+//     starWars := NewLegoSet(...)
+//     fmt.Println(starWars.Record)
+//     client.NewRecord(&starWars)
+//     fmt.Println(starWars.Record.LastModified)
+//
+// For more details see https://docs.kinto-storage.org/en/stable/api/1.x/records.html
+type Record struct {
+	Id           string `json:"id,omitempty"`
+	LastModified uint64 `json:"last_modified,omitempty"`
+}
+
+func (r *Record) ID() string {
+	return r.Id
+}
+
+type Recorded interface {
+	ID() string
+}

--- a/kinto/api/resource.go
+++ b/kinto/api/resource.go
@@ -8,8 +8,8 @@ package api
 // a given endpoint. The returned string should fulfill
 // all paths BEYOND the base path and "rest" resource (proto>://<hostname>/rest).
 //
-// E.G. If we are accessing a bug at "https://bugzilla-dev.allizom.org" then
-// this method should return "/bug/<id>"
+// E.G. If we are bucket a resource at "https://firefox.settings.services.mozilla.com/v1" then
+// this method should return "/buckets/<name>"
 type Resourcer interface {
 	Resource() string
 }

--- a/kinto/api/resource.go
+++ b/kinto/api/resource.go
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package api
+
+// A Resourcer returns the REST API resource for accessing
+// a given endpoint. The returned string should fulfill
+// all paths BEYOND the base path and "rest" resource (proto>://<hostname>/rest).
+//
+// E.G. If we are accessing a bug at "https://bugzilla-dev.allizom.org" then
+// this method should return "/bug/<id>"
+type Resourcer interface {
+	Resource() string
+}
+
+type Getter interface {
+	Get() string
+}
+
+type Poster interface {
+	Post() string
+}
+
+type Patcher interface {
+	Patch() string
+}

--- a/kinto/client.go
+++ b/kinto/client.go
@@ -1,0 +1,403 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package kinto // import "github.com/mozilla/OneCRL-Tools/kinto"
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/authz"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/plugins/kintosigner"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/batch"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/buckets"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/auth"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api"
+)
+
+type expectations map[int]bool
+
+var (
+	ok          = expectations{http.StatusOK: true}
+	okOrCreated = expectations{http.StatusOK: true, http.StatusCreated: true}
+)
+
+// Client is a thread safe client for the Kinto REST API.
+//
+// For information on the API that this client targets,
+// please see the Kinto 1.x API documentation:
+//
+// https://docs.kinto-storage.org/en/stable/api/
+type Client struct {
+	host          string
+	base          string
+	scheme        string
+	tool          string
+	backoff       time.Duration
+	authenticator auth.Authenticator
+	inner         *http.Client
+	lock          sync.Mutex
+}
+
+// NewClient constructs a client with the scheme (E.G "https"),
+// the host (E.G "settings.stage.mozaws.net"), and the API base (E.G "/v1").
+func NewClient(scheme, host, base string) *Client {
+	return &Client{
+		host:          host,
+		base:          base,
+		scheme:        scheme,
+		inner:         new(http.Client),
+		authenticator: new(auth.Unauthenticated),
+		tool:          "https://github.com/mozilla/OneCRL-Tools/kinto",
+		lock:          sync.Mutex{},
+	}
+}
+
+// WithAuthenticator sets the authentication backend for future requests. The use of this
+// configuration lazy and done on a per-request basis, so it is possible to use the same
+// client but swap accounts in-and-out as necessary.
+//
+// Although this API is thread safe it is not advised to swap out authentication methods
+// for client that is shared between goroutines as other threads may be assuming that a
+// given authenticator is being  used, which can lead to surprising results.
+func (c *Client) WithAuthenticator(authenticator auth.Authenticator) *Client {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.authenticator = authenticator
+	return c
+}
+
+// WithToolHeader sets the header value for X-AUTOMATED-TOOL, which
+// is sent with every request.
+//
+// By default, this is set to "https://github.com/mozilla/OneCRL-Tools/kinto",
+// however it would be appreciated if consumers of this library set this to
+// pointer to the code that is actually making API calls.
+func (c *Client) WithToolHeader(tool string) *Client {
+	c.tool = tool
+	return c
+}
+
+// Alive returns back whether any error occurred while doing a GET on /
+func (c *Client) Alive() bool {
+	req, err := c.newRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		panic(err)
+	}
+	return c.do(req, nil, nil) == nil
+}
+
+// NewAdmin is the same as NewAccount, however with the "admin" user pre-configured.
+func (c *Client) NewAdmin(password string) error {
+	return c.NewAccount(&auth.User{
+		Username: "admin",
+		Password: password,
+	})
+}
+
+// NewAccount creates a new Kinto local account using the provide principal and password.
+//
+// See https://docs.kinto-storage.org/en/stable/api/1.x/accounts.html#put--accounts-(user_id) for details.
+func (c *Client) NewAccount(user *auth.User) error {
+	payload := api.NewPayload(user, nil)
+	req, err := c.newRequest(http.MethodPut, user.Put(), &payload)
+	if err != nil {
+		return err
+	}
+	return c.do(req, &payload, okOrCreated)
+}
+
+// NewBucket creates a new bucket with default permissions.
+//
+// See https://docs.kinto-storage.org/en/stable/api/1.x/buckets.html#post--buckets for details.
+func (c *Client) NewBucket(bucket *buckets.Bucket) error {
+	return c.NewBucketWithPermissions(bucket, nil)
+}
+
+// NewBucketWithPermissions creates a new bucket with the provided permissions.
+//
+// See https://docs.kinto-storage.org/en/stable/api/1.x/buckets.html#post--buckets for details.
+func (c *Client) NewBucketWithPermissions(bucket *buckets.Bucket, perms *authz.Permissions) error {
+	payload := api.NewPayload(bucket, perms)
+	req, err := c.newRequest(http.MethodPost, bucket.Post(), &payload)
+	if err != nil {
+		return err
+	}
+	return c.do(req, &payload, okOrCreated)
+}
+
+// NewCollection creates a new collection with the provided permissions.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/collections.html#post--buckets-(bucket_id)-collections
+func (c *Client) NewCollection(collection api.Poster) error {
+	return c.NewCollectionWithPermissions(collection, nil)
+}
+
+// NewCollectionWithPermissions creates a new collection with the provided permissions.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/collections.html#post--buckets-(bucket_id)-collections
+func (c *Client) NewCollectionWithPermissions(collection api.Poster, perms *authz.Permissions) error {
+	payload := api.NewPayload(collection, perms)
+	req, err := c.newRequest(http.MethodPost, collection.Post(), &payload)
+	if err != nil {
+		return err
+	}
+	return c.do(req, &payload, okOrCreated)
+}
+
+// Batch POSTs a single batch request. Note that the size of a batch request is bounded
+// by the remote server's "batch_max_requests" settings (which can be found under "settings" under the root resource).
+//
+// The most reliable way to to use this endpoint is to query this limit via `BatchMaxRequests` and use that value
+// in the batch.NewBatches API.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/batch.html
+func (c *Client) Batch(b *batch.Batch) error {
+	req, err := c.newRequest(http.MethodPost, b.Post(), &b)
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil, okOrCreated)
+}
+
+// AllRecords retrieves all records for the given collection.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/records.html#retrieving-stored-records
+func (c *Client) AllRecords(collection api.Getter) error {
+	r, err := c.newRequest(http.MethodGet, collection.Get(), nil)
+	if err != nil {
+		return err
+	}
+	return c.do(r, collection, ok)
+}
+
+// NewRecord POSTs a new record under the given collection with default permissions.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/records.html#uploading-a-record
+func (c *Client) NewRecord(collection api.Getter, record interface{}) error {
+	return c.NewRecordWithPermissions(collection, record, nil)
+}
+
+// NewRecordWithPermissions POSTs a new record under the given collection with the given permissions.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/records.html#uploading-a-record
+func (c *Client) NewRecordWithPermissions(collection api.Getter, record interface{}, perms *authz.Permissions) error {
+	payload := api.NewPayload(record, perms)
+	req, err := c.newRequest(http.MethodPost, collection.Get(), &payload)
+	if err != nil {
+		return err
+	}
+	return c.do(req, &payload, okOrCreated)
+}
+
+// UpdateRecord PATCHes a given record under the given collection with default permissions.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/records.html#patch--buckets-(bucket_id)-collections-(collection_id)-records-(record_id)
+func (c *Client) UpdateRecord(collection api.Getter, record api.Recorded) error {
+	return c.UpdateRecordWithPermissions(collection, record, nil)
+}
+
+// UpdateRecordWithPermissions PATCHes a given record under the given collection with the given permissions.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/records.html#patch--buckets-(bucket_id)-collections-(collection_id)-records-(record_id)
+func (c *Client) UpdateRecordWithPermissions(collection api.Getter, record api.Recorded, perms *authz.Permissions) error {
+	payload := api.NewPayload(record.(interface{}), perms)
+	req, err := c.newRequest(http.MethodPatch, collection.Get()+"/"+record.ID(), &payload)
+	if err != nil {
+		return err
+	}
+	return c.do(req, &payload, okOrCreated)
+}
+
+// ToReview puts the given collection into the "to-review" state.
+//
+// For details on the Kinto Signer plugin, please see:
+// https://github.com/Kinto/kinto-signer
+func (c *Client) ToReview(collection api.Patcher) error {
+	req, err := c.newRequest(http.MethodPatch, collection.Patch(), kintosigner.ToReview())
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil, okOrCreated)
+}
+
+// ToWIP puts the given collection into the "work-in-progress" state.
+//
+// For details on the Kinto Signer plugin, please see:
+// https://github.com/Kinto/kinto-signer
+func (c *Client) ToWIP(collection api.Patcher) error {
+	req, err := c.newRequest(http.MethodPatch, collection.Patch(), kintosigner.WIP())
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil, okOrCreated)
+}
+
+// ToSign puts the given collection into the "to-sign" state.
+//
+// For details on the Kinto Signer plugin, please see:
+// https://github.com/Kinto/kinto-signer
+func (c *Client) ToSign(collection api.Patcher) error {
+	req, err := c.newRequest(http.MethodPatch, collection.Patch(), kintosigner.ToSign())
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil, okOrCreated)
+}
+
+// ToSigned puts the given collection into the "signed" state.
+//
+// For details on the Kinto Signer plugin, please see:
+// https://github.com/Kinto/kinto-signer
+func (c *Client) ToSigned(collection api.Patcher) error {
+	req, err := c.newRequest(http.MethodPatch, collection.Patch(), kintosigner.Signed())
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil, okOrCreated)
+}
+
+// ToRollBack puts the given collection into the "to-rollback" state.
+//
+// For details on the Kinto Signer plugin, please see:
+// https://github.com/Kinto/kinto-signer
+func (c *Client) ToRollBack(collection api.Patcher) error {
+	req, err := c.newRequest(http.MethodPatch, collection.Patch(), kintosigner.ToRollback())
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil, okOrCreated)
+}
+
+// ToResign puts the given collection into the "to-resign" state.
+//
+// For details on the Kinto Signer plugin, please see:
+// https://github.com/Kinto/kinto-signer
+func (c *Client) ToResign(collection api.Patcher) error {
+	req, err := c.newRequest(http.MethodPatch, collection.Patch(), kintosigner.ToResign())
+	if err != nil {
+		return err
+	}
+	return c.do(req, nil, okOrCreated)
+}
+
+// TryAuth does a GET on the Kinto's root resource and checks for the presence of user
+// metadata in order to determine the configured authenticator successfully authenticates.
+//
+// See https://docs.kinto-storage.org/en/stable/api/1.x/authentication.html#try-authentication for details.
+func (c *Client) TryAuth() (bool, error) {
+	r, err := c.newRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		return false, err
+	}
+	ret := make(map[string]interface{})
+	err = c.do(r, &ret, map[int]bool{200: true})
+	if err != nil {
+		return false, err
+	}
+	_, authenticated := ret["user"]
+	return authenticated, nil
+}
+
+// BatchMaxRequests retrieves the "settings.batch_max_requests" from the utility endpoint.
+//
+// This API is most useful when used in conjunction withe batch.NewBatches API.
+//
+// For details, please see:
+// https://docs.kinto-storage.org/en/stable/api/1.x/utilities.html#api-utilities
+func (c *Client) BatchMaxRequests() (int, error) {
+	answer := struct {
+		Settings struct {
+			BatchMaxRequests int `json:"batch_max_requests"`
+		} `json:"settings"`
+	}{}
+	r, err := c.newRequest(http.MethodGet, "/", nil)
+	if err != nil {
+		return 0, err
+	}
+	err = c.do(r, &answer, map[int]bool{200: true})
+	if err != nil {
+		return 0, err
+	}
+	return answer.Settings.BatchMaxRequests, nil
+}
+
+func (c *Client) newRequest(method string, endpoint string, body interface{}) (*http.Request, error) {
+	var b io.Reader
+	if body != nil {
+		bodyBytes, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		b = bytes.NewReader(bodyBytes)
+	}
+	req, err := http.NewRequest(method, fmt.Sprintf("%s://%s%s%s", c.scheme, c.host, c.base, endpoint), b)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("X-AUTOMATED-TOOL", c.tool)
+	return req, nil
+}
+
+func (c *Client) do(r *http.Request, target interface{}, accept expectations) error {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.authenticator.Authenticate(r)
+	if c.backoff > 0 {
+		// Kinto kindly asks us that we backoff when necessary
+		// See https://docs.kinto-storage.org/en/stable/api/1.x/backoff.html
+		log.Printf("Kinto has asked us to backoff for %d seconds\n", c.backoff)
+		time.Sleep(time.Second * c.backoff)
+	}
+	resp, err := c.inner.Do(r)
+	if err != nil {
+		return err
+	}
+	backoff := resp.Header.Get("Backoff")
+	if backoff != "" {
+		b, err := strconv.Atoi(backoff)
+		if err != nil {
+			return fmt.Errorf("Kinto gave us a Backoff header, but it did not parse to an integer. Got '%s'", backoff)
+		}
+		c.backoff = time.Second * time.Duration(b)
+	} else {
+		c.backoff = time.Duration(0)
+	}
+	if accept != nil {
+		if _, ok := accept[resp.StatusCode]; !ok {
+			defer resp.Body.Close()
+			b, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return fmt.Errorf("expected status code %v, got %d", accept, resp.StatusCode)
+			}
+			return fmt.Errorf("expected status code %v, got %d. Message %s", accept, resp.StatusCode, string(b))
+		}
+	}
+	if target != nil {
+		defer resp.Body.Close()
+		return json.NewDecoder(resp.Body).Decode(&target)
+	}
+	return nil
+}

--- a/kinto/go.mod
+++ b/kinto/go.mod
@@ -1,0 +1,3 @@
+module github.com/mozilla/OneCRL-Tools/kinto
+
+go 1.14

--- a/kinto/go.sum
+++ b/kinto/go.sum
@@ -1,0 +1,1 @@
+github.com/mozilla/OneCRL-Tools v0.0.0-20200615160823-f21fdfbaf3b6 h1:DX7WYrZ1VfsSmeul2P6ZhwAXyhedpwPHzrziJ1pg8vo=

--- a/kinto/kinto_test.go
+++ b/kinto/kinto_test.go
@@ -1,0 +1,289 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package kinto
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/authz"
+
+	"github.com/mozilla/OneCRL-Tools/kinto/api/auth"
+	"github.com/mozilla/OneCRL-Tools/kinto/api/batch"
+	"github.com/mozilla/OneCRL-Tools/kinto/api/buckets"
+	"github.com/mozilla/OneCRL-Tools/kinto/api/collections"
+)
+
+func NewOneCRL() *OneCRLCollection {
+	return &OneCRLCollection{
+		Collection: collections.NewCollection(buckets.NewBucket("security-state"), "onecrl"),
+		Data:       []OneCRLRecord{},
+	}
+}
+
+type OneCRLCollection struct {
+	*collections.Collection `json:"-"`
+	Data                    []OneCRLRecord `json:"data"`
+}
+
+type OneCRLRecord struct {
+	Schema       int     `json:"schema"`
+	Details      Details `json:"details"`
+	Enabled      bool    `json:"enabled"`
+	IssuerName   string  `json:"issuerName,omitempty"`
+	SerialNumber string  `json:"serialNumber,omitempty"`
+	Subject      string  `json:"subject,omitempty"`
+	PubKeyHash   string  `json:"pubKeyHash,omitempty"`
+	*api.Record
+}
+
+type Details struct {
+	Bug     string `json:"bug"`
+	Who     string `json:"who"`
+	Why     string `json:"why"`
+	Name    string `json:"name"`
+	Created string `json:"created"`
+}
+
+var Production = NewClient("https", "firefox.settings.services.mozilla.com", "/v1")
+
+var dev = &auth.User{
+	Username: "superDev",
+	Password: "password",
+}
+var admin = &auth.User{
+	Username: "admin",
+	Password: "password",
+}
+var local = NewClient("http", "localhost:8888", "/v1").WithAuthenticator(dev)
+
+var devRW = &authz.Permissions{
+	Read:  []string{"account:superDev"},
+	Write: []string{"account:superDev"},
+}
+
+func TestMain(m *testing.M) {
+	dir := os.Getenv("KINTO_TESTDIR")
+	if dir == "" {
+		os.Exit(m.Run())
+	}
+	down := exec.Command("docker-compose", "down")
+	down.Dir = dir
+	out, err := down.CombinedOutput()
+	if err != nil {
+		panic(fmt.Sprintf("KINTO_TESTDIR: '%s', Output: '%s', Error:'%v'", dir, string(out), err))
+	}
+	up := exec.Command("docker-compose", "up")
+	up.Dir = dir
+	err = up.Start()
+	if err != nil {
+		panic(err)
+	}
+	start := time.Now()
+	for !local.Alive() {
+		time.Sleep(time.Millisecond * 200)
+		if time.Now().Sub(start) > time.Minute {
+			panic("took more than ten seconds to docker-compose up")
+		}
+	}
+	local.WithAuthenticator(&auth.Unauthenticated{})
+	err = local.NewAdmin(admin.Password)
+	if err != nil {
+		panic(err)
+	}
+	local.WithAuthenticator(admin)
+	err = local.NewAccount(dev)
+	if err != nil {
+		panic(err)
+	}
+	oneCRL := NewOneCRL()
+	err = local.NewBucketWithPermissions(oneCRL.Bucket, devRW)
+	if err != nil {
+		panic(err)
+	}
+	err = local.NewCollectionWithPermissions(oneCRL.Collection, devRW)
+	if err != nil {
+		panic(err)
+	}
+	CopyProd()
+
+	signer := buckets.NewBucket("to_sign")
+	err = local.NewBucketWithPermissions(signer, devRW)
+	if err != nil {
+		panic(err)
+	}
+	signedOnecrl := collections.NewCollection(signer, "signedOnecrl")
+	err = local.NewCollectionWithPermissions(signedOnecrl, devRW)
+	if err != nil {
+		panic(err)
+	}
+
+	signed := buckets.NewBucket("signed")
+	err = local.NewBucketWithPermissions(signed, devRW)
+	if err != nil {
+		panic(err)
+	}
+	signedOnecrl = collections.NewCollection(signed, "signedOnecrl")
+	err = local.NewCollectionWithPermissions(signedOnecrl, devRW)
+	if err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+func CopyProd() {
+	oneCRL := NewOneCRL()
+	err := Production.AllRecords(oneCRL)
+	if err != nil {
+		panic(err)
+	}
+	records := make([]interface{}, len(oneCRL.Data))
+	for i, record := range oneCRL.Data {
+		records[i] = record
+	}
+	max, err := local.BatchMaxRequests()
+	if err != nil {
+		panic(err)
+	}
+	batches := batch.NewBatches(records, max, devRW, http.MethodPost, oneCRL.Get())
+	for _, b := range batches {
+		err = local.Batch(b)
+		if err != nil {
+			panic(err)
+		}
+	}
+	l := NewOneCRL()
+	p := NewOneCRL()
+	err = local.AllRecords(l)
+	if err != nil {
+		panic(err)
+	}
+	err = Production.AllRecords(p)
+	if err != nil {
+		panic(err)
+	}
+	if !reflect.DeepEqual(l.Data, p.Data) {
+		panic(fmt.Sprintf("production and local did not match each other.\ngot: %v\nwant: %v", l.Data, p.Data))
+	}
+}
+
+func TestKintoSigner(t *testing.T) {
+	signer := buckets.NewBucket("to_sign")
+	onecrl := collections.NewCollection(signer, "signedOnecrl")
+	record := &OneCRLRecord{
+		IssuerName: "honest achmed's",
+	}
+	err := local.NewRecord(onecrl, record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = local.ToReview(onecrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = local.ToSign(onecrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = local.ToSigned(onecrl)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewRecord(t *testing.T) {
+	record := &OneCRLRecord{
+		IssuerName: "honest achmed's",
+	}
+	err := local.NewRecord(NewOneCRL(), record)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPatchRecord(t *testing.T) {
+	record := &OneCRLRecord{
+		IssuerName: "Honest Achmed's",
+		Details: Details{
+			Why: "dunno, seemed like a good guy",
+		},
+	}
+	err := local.NewRecord(NewOneCRL(), record)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if record.Record == nil {
+		t.Fatal("Failed to deserialize return structure")
+	}
+	record.Details.Bug = "https://bugzilla.mozilla.org/show_bug.cgi?id=647959"
+	err = local.UpdateRecord(NewOneCRL(), record)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetOneCRL(t *testing.T) {
+	err := local.AllRecords(NewOneCRL())
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTryAuth(t *testing.T) {
+	c := NewClient("http", "localhost:8888", "/v1").WithAuthenticator(admin)
+	authed, err := c.TryAuth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !authed {
+		t.Fatal("expected to be authenticated")
+	}
+}
+
+func TestTryAuthFail(t *testing.T) {
+	c := NewClient("http", "localhost:8888", "/v1").WithAuthenticator(&auth.User{
+		Username: "chris",
+		Password: "nyope",
+	})
+	authed, err := c.TryAuth()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if authed {
+		t.Fatal("expected to be unauthenticated")
+	}
+}
+
+func TestNewAccount(t *testing.T) {
+	c := NewClient("http", "localhost:8888", "/v1").WithAuthenticator(admin)
+	err := c.NewAccount(&auth.User{Username: "chris", Password: "password1234"})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewBucket(t *testing.T) {
+	b := buckets.NewBucket("security-state")
+	err := local.NewBucketWithPermissions(b, devRW)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewCollection(t *testing.T) {
+	bucket := buckets.NewBucket("security-state")
+	collection := collections.NewCollection(bucket, "onecrl")
+	err := local.NewCollectionWithPermissions(collection, devRW)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/kinto/local/config/__init__.py
+++ b/kinto/local/config/__init__.py
@@ -1,0 +1,77 @@
+import codecs
+import logging
+import os
+from time import strftime
+
+from kinto import __version__
+from kinto.core import utils as core_utils
+
+logger = logging.getLogger(__name__)
+
+HERE = os.path.dirname(__file__)
+
+
+def render_template(template, destination, **kwargs):
+    template = os.path.join(HERE, template)
+    folder = os.path.dirname(destination)
+
+    if folder and not os.path.exists(folder):
+        os.makedirs(folder)
+
+    logger.info(f"Created config {os.path.abspath(destination)}")
+
+    with codecs.open(template, "r", encoding="utf-8") as f:
+        raw_template = f.read()
+        rendered = raw_template.format_map(kwargs)
+        with codecs.open(destination, "w+", encoding="utf-8") as output:
+            output.write(rendered)
+
+
+postgresql_url = "postgresql://postgres:postgres@localhost/postgres"
+redis_url = "redis://localhost:6379"
+
+backend_to_values = {
+    "postgresql": {
+        "storage_backend": "kinto.core.storage.postgresql",
+        "storage_url": postgresql_url,
+        "permission_backend": "kinto.core.permission.postgresql",
+        "permission_url": postgresql_url,
+    },
+    "redis": {
+        "storage_backend": "kinto_redis.storage",
+        "storage_url": redis_url + "/1",
+        "permission_backend": "kinto_redis.permission",
+        "permission_url": redis_url + "/3",
+    },
+    "memory": {
+        "storage_backend": "kinto.core.storage.memory",
+        "storage_url": "",
+        "permission_backend": "kinto.core.permission.memory",
+        "permission_url": "",
+    },
+}
+
+cache_backend_to_values = {
+    "postgresql": {"cache_backend": "kinto.core.cache.postgresql", "cache_url": postgresql_url},
+    "redis": {"cache_backend": "kinto_redis.cache", "cache_url": redis_url + "/2"},
+    "memcached": {
+        "cache_backend": "kinto.core.cache.memcached",
+        "cache_url": "127.0.0.1:11211 127.0.0.2:11211",
+    },
+    "memory": {"cache_backend": "kinto.core.cache.memory", "cache_url": ""},
+}
+
+
+def init(config_file, backend, cache_backend, host="127.0.0.1"):
+    values = {}
+
+    values["host"] = host
+    values["secret"] = core_utils.random_bytes_hex(32)
+
+    values["kinto_version"] = __version__
+    values["config_file_timestamp"] = str(strftime("%a, %d %b %Y %H:%M:%S %z"))
+
+    values.update(backend_to_values[backend])
+    values.update(cache_backend_to_values[cache_backend])
+
+    render_template("kinto.tpl", config_file, **values)

--- a/kinto/local/config/kinto.tpl
+++ b/kinto/local/config/kinto.tpl
@@ -1,0 +1,271 @@
+# Created at {config_file_timestamp}
+# Using Kinto version {kinto_version}
+# Full options list for .ini file
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html
+
+
+[server:main]
+use = egg:waitress#main
+host = {host}
+port = %(http_port)s
+
+
+[app:main]
+use = egg:kinto
+
+# Feature settings
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#feature-settings
+#
+# kinto.readonly = false
+# kinto.batch_max_requests = 25
+# kinto.paginate_by =
+# Experimental JSON-schema on collection
+# kinto.experimental_collection_schema_validation = false
+#
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#activating-the-permissions-endpoint
+# kinto.experimental_permissions_endpoint = false
+#
+# kinto.trailing_slash_redirect_enabled = true
+# kinto.heartbeat_timeout_seconds = 10
+
+# Plugins
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#plugins
+# https://github.com/uralbash/awesome-pyramid
+kinto.includes = kinto.plugins.default_bucket
+                 kinto.plugins.admin
+                 kinto.plugins.accounts
+                 kinto_signer
+#                kinto.plugins.history
+#                kinto.plugins.quotas
+
+kinto.signer.resources =
+    /buckets/to_sign/collections/onecrl -> /buckets/signed/collections/onecrl
+
+# Backends
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#storage
+#
+kinto.storage_backend = {storage_backend}
+kinto.storage_url = {storage_url}
+# kinto.storage_max_fetch_size = 10000
+# kinto.storage_pool_size = 25
+# kinto.storage_max_overflow = 5
+# kinto.storage_pool_recycle = -1
+# kinto.storage_pool_timeout = 30
+# kinto.storage_max_backlog = -1
+
+# Cache
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#cache
+#
+kinto.cache_backend = {cache_backend}
+kinto.cache_url = {cache_url}
+# kinto.cache_prefix =
+# kinto.cache_max_size_bytes = 524288
+# kinto.cache_pool_size = 25
+# kinto.cache_max_overflow = 5
+# kinto.cache_pool_recycle = -1
+# kinto.cache_pool_timeout = 30
+# kinto.cache_max_backlog = -1
+
+# kinto.cache_backend = kinto.core.cache.memcached
+# kinto.cache_hosts = 127.0.0.1:11211
+
+# Permissions.
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#permissions
+#
+kinto.permission_backend = {permission_backend}
+kinto.permission_url = {permission_url}
+# kinto.permission_pool_size = 25
+# kinto.permission_max_overflow = 5
+# kinto.permission_pool_recycle = 1
+# kinto.permission_pool_timeout = 30
+# kinto.permission_max_backlog - 1
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#bypass-permissions-with-configuration
+# kinto.bucket_create_principals = system.Authenticated
+
+# Authentication
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#authentication
+#
+kinto.userid_hmac_secret = {secret}
+multiauth.policies = account
+# Any pyramid multiauth setting can be specified for custom authentication
+# https://github.com/uralbash/awesome-pyramid#authentication
+#
+# Accounts API configuration
+#
+# Enable built-in plugin.
+# Set `kinto.includes` to `kinto.plugins.accounts`
+# Enable authenticated policy.
+# Set `multiauth.policies` to `account`
+multiauth.policy.account.use = kinto.plugins.accounts.AccountsPolicy
+# Allow anyone to create accounts.
+kinto.account_create_principals = system.Everyone
+# Set user 'account:admin' as the administrator.
+kinto.account_write_principals = account:admin
+# Allow administrators to create buckets
+kinto.bucket_create_principals = account:admin
+# Enable the "account_validation" option.
+# kinto.account_validation = true
+# Set the sender for the validation email.
+# kinto.account_validation.email_sender = "admin@example.com"
+# Set the regular expression used to validate a proper email address.
+# kinto.account_validation.email_regexp = "^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$"
+
+# Mail configuration (needed for the account validation option), see https://docs.pylonsproject.org/projects/pyramid_mailer/en/latest/#configuration
+# mail.host = localhost
+# mail.port = 25
+# mail.username = someusername
+# mail.password = somepassword
+
+# Notifications
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#notifications
+#
+# Configuration example:
+# kinto.event_listeners = redis
+# kinto.event_listeners.redis.use = kinto_redis.listeners
+# kinto.event_listeners.redis.url = redis://localhost:6379/0
+# kinto.event_listeners.redis.pool_size = 5
+# kinto.event_listeners.redis.listname = queue
+# kinto.event_listeners.redis.actions = create
+# kinto.event_listeners.redis.resources = bucket collection
+
+# Production settings
+#
+# https://kinto.readthedocs.io/en/latest/configuration/production.html
+
+# kinto.http_scheme = https
+# kinto.http_host = kinto.services.mozilla.com
+
+# Cross Origin Requests
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#cross-origin-requests-cors
+#
+# kinto.cors_origins = *
+
+# Backoff indicators/end of service
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#backoff-indicators
+# https://kinto.readthedocs.io/en/latest/api/1.x/backoff.html#id1
+#
+# kinto.backoff =
+# kinto.backoff_percentage =
+# kinto.retry_after_seconds = 3
+# kinto.eos =
+# kinto.eos_message =
+# kinto.eos_url =
+
+# Project information
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#project-information
+#
+# kinto.version_json_path = ./version.json
+# kinto.error_info_link = https://github.com/kinto/kinto/issues/
+# kinto.project_docs = https://kinto.readthedocs.io
+# kinto.project_name = kinto
+# kinto.project_version =
+# kinto.version_prefix_redirect_enabled = true
+
+# Application profilling
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#application-profiling
+# kinto.profiler_enabled = true
+# kinto.profiler_dir = /tmp/profiling
+
+# Client cache headers
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#client-caching
+#
+# Every bucket objects objects and list
+# kinto.bucket_cache_expires_seconds = 3600
+#
+# Every collection objects and list of every buckets
+# kinto.collection_cache_expires_seconds = 3600
+#
+# Every group objects and list of every buckets
+# kinto.group_cache_expires_seconds = 3600
+#
+# Every records objects and list of every collections
+# kinto.record_cache_expires_seconds = 3600
+#
+# Records in a specific bucket
+# kinto.blog_record_cache_expires_seconds = 3600
+#
+# Records in a specific collection in a specific bucket
+# kinto.blog_article_record_cache_expires_seconds = 3600
+
+# Custom ID generator for POST Requests
+# https://kinto.readthedocs.io/en/latest/tutorials/custom-id-generator.html#tutorial-id-generator
+#
+# Default generator
+# kinto.bucket_id_generator=kinto.views.NameGenerator
+# Custom example
+# kinto.collection_id_generator = name_generator.CollectionGenerator
+# kinto.group_id_generator = name_generator.GroupGenerator
+# kinto.record_id_generator = name_generator.RecordGenerator
+
+# Enabling or disabling endpoints
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#enabling-or-disabling-endpoints
+#
+# This is a rather confusing setting due to naming conventions used in kinto.core
+# For a more in depth explanation, refer to https://github.com/Kinto/kinto/issues/710
+# kinto.endpoint_type_resource_name_method_enabled = false
+# Where:
+# endpoint_type: is either ``collection`` (plural, e.g. ``/buckets``) or ``record`` (single, e.g. ``/buckets/abc``);
+# resource_name: is the name of the resource (e.g. ``bucket``, ``group``, ``collection``, ``record``);
+# method: is the http method (in lower case) (e.g. ``get``, ``post``, ``put``, ``patch``, ``delete``).
+# For example, to disable the POST on the list of buckets and DELETE on single records
+# kinto.collection_bucket_post_enabled = false
+# kinto.record_record_delete_enabled = false
+
+# [uwsgi]
+# wsgi-file = app.wsgi
+# enable-threads = true
+# socket = /var/run/uwsgi/kinto.sock
+# chmod-socket = 666
+# processes =  3
+# master = true
+# module = kinto
+# harakiri = 120
+# uid = kinto
+# gid = kinto
+# virtualenv = .venv
+# lazy = true
+# lazy-apps = true
+# single-interpreter = true
+# buffer-size = 65535
+# post-buffering = 65535
+# plugin = python
+
+# Logging and Monitoring
+#
+# https://kinto.readthedocs.io/en/latest/configuration/settings.html#logging-and-monitoring
+# kinto.statsd_backend = kinto.core.statsd
+# kinto.statsd_prefix = kinto
+# kinto.statsd_url =
+
+# kinto.newrelic_config =
+# kinto.newrelic_env = dev
+
+# Logging configuration
+
+[loggers]
+keys = root, kinto
+
+[handlers]
+keys = console
+
+[formatters]
+keys = color
+
+[logger_root]
+level = INFO
+handlers = console
+
+[logger_kinto]
+level = DEBUG
+handlers = console
+qualname = kinto
+propagate = 0
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = color
+
+[formatter_color]
+class = logging_color_formatter.ColorFormatter

--- a/kinto/local/docker-compose.yml
+++ b/kinto/local/docker-compose.yml
@@ -1,0 +1,23 @@
+db:
+  image: postgres
+  environment:
+    POSTGRES_USER: postgres
+    POSTGRES_PASSWORD: postgres
+cache:
+  image: library/memcached
+web:
+  image: kinto/kinto-server
+  volumes:
+    - ./config:/app/kinto/config
+  links:
+   - db
+   - cache
+  ports:
+   - "8888:8888"
+  environment:
+    KINTO_CACHE_BACKEND: kinto.core.cache.memcached
+    KINTO_CACHE_HOSTS: cache:11211 cache:11212
+    KINTO_STORAGE_BACKEND: kinto.core.storage.postgresql
+    KINTO_STORAGE_URL: postgresql://postgres:postgres@db/postgres
+    KINTO_PERMISSION_BACKEND: kinto.core.permission.postgresql
+    KINTO_PERMISSION_URL: postgresql://postgres:postgres@db/postgres

--- a/kinto/plugins/kintosigner/signer.go
+++ b/kinto/plugins/kintosigner/signer.go
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package kintosigner
+
+type Status struct {
+	Data KintoStatus `json:"data"`
+}
+
+type KintoStatus struct {
+	Status string `json:"status"`
+}
+
+func WIP() Status {
+	return Status{Data: KintoStatus{Status: "work-in-progress"}}
+}
+
+func ToReview() Status {
+	return Status{Data: KintoStatus{Status: "to-review"}}
+}
+
+func ToSign() Status {
+	return Status{Data: KintoStatus{Status: "to-sign"}}
+}
+
+func Signed() Status {
+	return Status{Data: KintoStatus{Status: "signed"}}
+}
+
+func ToRollback() Status {
+	return Status{Data: KintoStatus{Status: "to-rollback"}}
+}
+
+func ToResign() Status {
+	return Status{Data: KintoStatus{Status: "to-resign"}}
+}


### PR DESCRIPTION
This change introduces some generic bindings to the Kinto 1.x REST API as well as the Kinto Signer plugin. Note that this is not actually a 1400 addition change as there is some copy-pastaed configuration and Python files that are necessary for local test instances.

The [Client](https://github.com/christopher-henderson/OneCRL-Tools/blob/kinto/kinto/client.go) is the entry point to the API.

By injecting an environment variable and asking Travis to make a Docker daemon available to me ([.travis.yml](https://github.com/christopher-henderson/OneCRL-Tools/blob/kinto/.travis.yml)) I was able to some fairly decent test coverage over GET/POST/PATCH APIs as well batch requests and utility endpoints (for things such as "try_auth").

Note that I was not able to test this with bearer token authorization as, given the moderate time constraints, I could not think of a nice way to register a local dev instance for any stable and openly available authz service. I also tried my best to honor Kinto niceness contracts by trying to read a Backoff header, however I was not able to recreate the scenario in which case I would actually receive this header.