### PR TITLE
Move the binary to ENTRYPOINT and remove CMD

### DIFF
--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -24,4 +24,3 @@ USER app
 WORKDIR /app
 
 ENTRYPOINT [ "/app/ccadb2OneCRL" ]
-CMD [ "/config/config.env" ]

--- a/containers/Dockerfile
+++ b/containers/Dockerfile
@@ -23,4 +23,5 @@ RUN touch /config/config.env
 USER app
 WORKDIR /app
 
-CMD [ "/app/ccadb2OneCRL", "/config/config.env" ]
+ENTRYPOINT [ "/app/ccadb2OneCRL" ]
+CMD [ "/config/config.env" ]


### PR DESCRIPTION
Overriding the CMD in jenkins is proving difficult where all configuration is being passed via env vars.

Can the dev tooling simply inline the config file to docker run when needed?