### PR TITLE
Use new Remote Settings STAGE URL

### DIFF
--- a/ccadb2OneCRL/README.md
+++ b/ccadb2OneCRL/README.md
@@ -90,8 +90,8 @@ ONECRL_PRODUCTION_TOKEN=
 # Default is likely what you want as this is mostly configurable for testing purposes.
 #ONECRL_PRODUCTION_COLLECTION="onecrl"
 
-# Base URL for Kinto production [default: "https://settings.stage.mozaws.net/v1"]
-#ONECRL_STAGING="https://settings.stage.mozaws.net/v1"
+# Base URL for Kinto production [default: "https://settings-cdn.stage.mozaws.net/v1"]
+#ONECRL_STAGING="https://settings-cdn.stage.mozaws.net/v1"
 
 # User account for Kinto staging. Requires OneCRLStagingPassword to be set. Mutually exclusive with OneCRLStagingToken.
 #ONECRL_STAGING_USER=

--- a/ccadb2OneCRL/config.env
+++ b/ccadb2OneCRL/config.env
@@ -22,8 +22,8 @@ ONECRL_PRODUCTION_TOKEN=
 # Default is likely what you want as this is mostly configurable for testing purposes.
 #ONECRL_PRODUCTION_COLLECTION="onecrl"
 
-# Base URL for Kinto production [default: "https://settings.stage.mozaws.net/v1"]
-#ONECRL_STAGING="https://settings.stage.mozaws.net/v1"
+# Base URL for Kinto production [default: "https://settings-cdn.stage.mozaws.net/v1"]
+#ONECRL_STAGING="https://settings-cdn.stage.mozaws.net/v1"
 
 # User account for Kinto staging. Requires OneCRLStagingPassword to be set. Mutually exclusive with OneCRLStagingToken.
 #ONECRL_STAGING_USER=

--- a/ccadb2OneCRL/main.go
+++ b/ccadb2OneCRL/main.go
@@ -50,9 +50,9 @@ const (
 	// Target production collection [default: "onecrl"]
 	// Default is likely what you want as this is mostly configurable for testing purposes.
 	OneCRLProductionCollection = "ONECRL_PRODUCTION_COLLECTION"
-	// Base URL for Kinto production [default: "https://settings.stage.mozaws.net/v1"]
+	// Base URL for Kinto production [default: "https://settings-cdn.stage.mozaws.net/v1"]
 	OneCRLStaging        = "ONECRL_STAGING"
-	oneCRLStagingDefault = "https://settings.stage.mozaws.net/v1"
+	oneCRLStagingDefault = "https://settings-cdn.stage.mozaws.net/v1"
 	// User account for Kinto staging. Requires OneCRLStagingPassword to be set. Mutually exclusive with OneCRLStagingToken.
 	OneCRLStagingUser = "ONECRL_STAGING_USER"
 	// User password for Kinto staging. Requires OneCRLStagingUser to be set. Mutually exclusive with OneCRLStagingToken.

--- a/ccadb2OneCRL/main_test.go
+++ b/ccadb2OneCRL/main_test.go
@@ -57,7 +57,7 @@ var devRW = &authz.Permissions{
 }
 
 var local = kinto.NewClient("http", "localhost:8888", "/v1").WithAuthenticator(dev)
-var staging = kinto.NewClient("https", "settings.stage.mozaws.net", "/v1")
+var staging = kinto.NewClient("https", "settings-cdn.stage.mozaws.net", "/v1")
 var production = kinto.NewClient("https", "firefox.settings.services.mozilla.com", "/v1")
 
 func setup() {

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ import (
 )
 
 const ProductionPrefix string = "https://firefox.settings.services.mozilla.com"
-const StagePrefix string = "https://settings.stage.mozaws.net"
+const StagePrefix string = "https://settings-cdn.stage.mozaws.net"
 const RecordsPathPrefix string = "/v1/buckets/"
 const RecordsPathSuffix string = "/collections/onecrl/records"
 

--- a/kinto/client.go
+++ b/kinto/client.go
@@ -50,7 +50,7 @@ type Client struct {
 }
 
 // NewClient constructs a client with the scheme (E.G "https"),
-// the host (E.G "settings.stage.mozaws.net"), and the API base (E.G "/v1").
+// the host (E.G "settings-cdn.stage.mozaws.net"), and the API base (E.G "/v1").
 func NewClient(scheme, host, base string) *Client {
 	return &Client{
 		host:          host,

--- a/one_crl_to_cert_storage/src/one_crl/mod.rs
+++ b/one_crl_to_cert_storage/src/one_crl/mod.rs
@@ -10,7 +10,7 @@ use std::convert::TryInto;
 use crate::errors::*;
 
 const PRODUCTION: &str = "https://firefox.settings.services.mozilla.com/v1/buckets/security-state/collections/onecrl/records";
-const STAGING: &str =  "https://settings.stage.mozaws.net/v1/buckets/security-state/collections/onecrl/records";
+const STAGING: &str =  "https://settings-cdn.stage.mozaws.net/v1/buckets/security-state/collections/onecrl/records";
 
 pub enum Environment {
     Production,


### PR DESCRIPTION
In [Bug 1594573](https://bugzilla.mozilla.org/show_bug.cgi?id=1594573), we fixed some inconsistencies between our prod and stage URLs.

This is the new URL to be used for the STAGE public server.