### PR TITLE
ccadb2OneCRL: preserve leading zeros on serial numbers

### DIFF
--- a/ccadb2OneCRL/ccadb/ccadb.go
+++ b/ccadb2OneCRL/ccadb/ccadb.go
@@ -16,6 +16,7 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/mozilla/OneCRL-Tools/ccadb2OneCRL/set"
+	"github.com/mozilla/OneCRL-Tools/ccadb2OneCRL/utils"
 	"github.com/pkg/errors"
 
 	"github.com/gocarina/gocsv"
@@ -86,7 +87,14 @@ func (c *Certificate) IssuerSerial() *set.IssuerSerial {
 			Warn("failed to parse the CCADB certificate when constructing a Issuer:Serial pair")
 		return nil
 	}
-	is := set.NewIssuerSerial(cert.RawIssuer, cert.SerialNumber.Bytes())
+	serial, err := utils.RawSerialBytes(cert.RawTBSCertificate)
+	if err != nil {
+		log.WithError(err).
+			WithField("revocation", c).
+			Warn("failed to parse serial number")
+		return nil
+	}
+	is := set.NewIssuerSerial(cert.RawIssuer, serial)
 	return &is
 }
 

--- a/ccadb2OneCRL/onecrl/onecrl.go
+++ b/ccadb2OneCRL/onecrl/onecrl.go
@@ -231,6 +231,10 @@ func FromCCADB(c *ccadb.Certificate) (*Record, error) {
 	if err != nil {
 		return nil, err
 	}
+	serial, err := utils.RawSerialBytes(cert.RawTBSCertificate)
+	if err != nil {
+		return nil, err
+	}
 	record := &Record{
 		CCADB: c,
 		Details: Details{
@@ -242,7 +246,7 @@ func FromCCADB(c *ccadb.Certificate) (*Record, error) {
 		},
 		Enabled:      false,
 		IssuerName:   utils.B64Encode(cert.RawIssuer),
-		SerialNumber: utils.B64Encode(cert.SerialNumber.Bytes()),
+		SerialNumber: utils.B64Encode(serial),
 		Subject:      "",
 		PubKeyHash:   "",
 	}

--- a/ccadb2OneCRL/utils/normalize.go
+++ b/ccadb2OneCRL/utils/normalize.go
@@ -5,12 +5,29 @@
 package utils
 
 import (
+	"encoding/asn1"
 	"encoding/base64"
 	"fmt"
 	"strings"
 
 	"github.com/pkg/errors"
 )
+
+type tbsCertWithRawSerial struct {
+	Raw          asn1.RawContent
+	Version      asn1.RawValue `asn1:"optional,explicit,default:0,tag:0"`
+	SerialNumber asn1.RawValue
+}
+
+// Extract the raw bytes of the serial number field from a tbsCertificate..
+func RawSerialBytes(rawTBSCertificate []byte) ([]byte, error) {
+	var tbsCert tbsCertWithRawSerial
+	_, err := asn1.Unmarshal(rawTBSCertificate, &tbsCert)
+	if err != nil {
+		return nil, err
+	}
+	return tbsCert.SerialNumber.Bytes, nil
+}
 
 // B64Decode attempts to decode the give string first as an
 // RFC 4648 encoded string (with padding). If that fails, then

--- a/ccadb2OneCRL/utils/utils_test.go
+++ b/ccadb2OneCRL/utils/utils_test.go
@@ -20,6 +20,20 @@ func assertBytes(t *testing.T, data string, expected []byte) {
 	}
 }
 
+func TestRawSerialBytes(t *testing.T) {
+	// DER for the version and serialNumber fields of a tbsCertificate.
+	tbsCertPrefix := []byte{
+		0x30, 0x0f,
+		0xa0, 0x03, 0x02, 0x01, 0x02,
+		0x02, 0x08, 0x00, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa,
+	}
+
+	b, _ := RawSerialBytes(tbsCertPrefix)
+	if !bytes.Equal(b, []byte{0x00, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa}) {
+		t.Errorf("error")
+	}
+}
+
 func TestBase64Decoder(t *testing.T) {
 	// Tolerate spaces
 	assertBytes(t, "b2theSB0aGVyZQ==", []byte("okay there"))


### PR DESCRIPTION
Resolves #190 